### PR TITLE
Normalize send/recv functions, add timeout to c2s & s2c tests

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -124,7 +124,6 @@ func readNdtMessage(ws *websocket.Conn, expectedType byte) ([]byte, error) {
 	}
 	// Verify that the expected length matches the given data.
 	expectedLen := int(inbuff[1])<<8 + int(inbuff[2])
-	log.Println(expectedLen)
 	if expectedLen != len(inbuff[3:]) {
 		return nil, fmt.Errorf("Message length (%d) does not match length of data received (%d)",
 			expectedLen, len(inbuff[3:]))


### PR DESCRIPTION
This change normalizes the send/recv and read/write operations for ndt messages. NdtJSONMessage is now marshaled using a native Go struct. All functions return errors rather than calling `log.Fatal`.

Timeout conditions are added to both s2c and c2s tests using a 15sec context created from the control channel. The value returned is now `bytesPerSecond`. The test "managers" convert that value to Kbps.

The `TestResponder` struct is expanded to include additional helper routines to simplify the S2C and C2S Test handlers.

There are some lint and variable name improvements.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-cloud/10)
<!-- Reviewable:end -->
