### PR TITLE
Add lame duck support and handling SIGTERM

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -92,9 +92,6 @@ var (
 	lameDuck = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "lame_duck_experiment",
 		Help: "Indicates when the server is in lame duck",
-		ConstLabels: map[string]string{
-			"experiment": "ndt.iupui",
-		},
 	})
 )
 


### PR DESCRIPTION
This change adds support for catching SIGTERM, and setting a "lame duck" monitoring metric (normally zero) to one.

With this change, ndt-cloud will be able to respond to the kubernetes shutdown cycle.

The name and labels on the `lame_duck_experiment` metric are inherited from the current lame duck metric support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-cloud/12)
<!-- Reviewable:end -->
