### PR TITLE
travis: disable automatic go build, only use docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
-language: go
-go:
-- "1.11"
+# We don't care about the language because we build in a docker. Not doing
+# that and instead requiring go leads to failures caused by missing headers
+# on the build machine. So we use minimal, which is basically "no lang".
+#
+# See <https://docs.travis-ci.com/user/languages/minimal-and-generic/>
+# See <https://travis-ci.org/m-lab/ndt-server/builds/496487913>
+language: minimal
 
 services:
 - docker


### PR DESCRIPTION
This has been written as part of #62, which is currently WIP. When trying to fix a broken build, I noticed that our current build will build files not only inside docker but also outside docker, i.e. in travis.

This happens because we're using as build language `go`. However, the current testing system is such that we want to do everything inside containers. Hence, disable building stuff outside.

(In #62 I am removing C code and using Go directly to get BBR stats. The build fails in travis because of missing header definitions, and succeeds in containers because such definitons are present.)

Asking a review to @pboothe because he most recently worked on the travis build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/63)
<!-- Reviewable:end -->
