### PR TITLE
spec: use int64, allow counter-flow messages

### DIFF
--- a/bbr/bbr_linux.go
+++ b/bbr/bbr_linux.go
@@ -60,7 +60,10 @@ func getMaxBandwidthAndMinRTT(fp *os.File) (model.BBRInfo, error) {
 		return metrics, syscall.EOVERFLOW
 	}
 	maxbw *= 8 // bytes/s to bits/s
-	metrics.MaxBandwidth = float64(maxbw)
+	if maxbw > math.MaxInt64 {
+		return metrics, syscall.EOVERFLOW
+	}
+	metrics.MaxBandwidth = int64(maxbw)  // Java has no uint64
 	metrics.MinRTT = float64(bbrip.bbr_min_rtt)
 	metrics.MinRTT /= 1000.0 // microseconds to milliseconds
 	return metrics, nil

--- a/ndt7/client.go
+++ b/ndt7/client.go
@@ -41,7 +41,7 @@ func (cl Client) Download() error {
 	conn.SetReadLimit(spec.MinMaxMessageSize)
 	defer conn.Close()
 	t0 := time.Now()
-	num := float64(0.0)
+	num := int64(0.0)
 	ticker := time.NewTicker(minMeasurementInterval)
 	log.Info("Starting download")
 	for {
@@ -69,7 +69,7 @@ func (cl Client) Download() error {
 			}
 			break
 		}
-		num += float64(len(mdata))
+		num += int64(len(mdata))
 		if mtype == websocket.TextMessage {
 			// Unmarshal to verify that this message is correct JSON but do not
 			// otherwise process the message's content.

--- a/ndt7/model/appinfo.go
+++ b/ndt7/model/appinfo.go
@@ -3,5 +3,5 @@ package model
 // AppInfo contains an application level measurement.
 type AppInfo struct {
 	// NumBytes is the number of bytes transferred so far.
-	NumBytes float64 `json:"num_bytes"`
+	NumBytes int64 `json:"num_bytes"`
 }

--- a/ndt7/model/bbrinfo.go
+++ b/ndt7/model/bbrinfo.go
@@ -4,7 +4,7 @@ package model
 // The BBRInfo struct contains information measured using BBR.
 type BBRInfo struct {
 	// MaxBandwidth is the max bandwidth measured by BBR in bits per second.
-	MaxBandwidth float64 `json:"max_bandwidth"`
+	MaxBandwidth int64 `json:"max_bandwidth"`
 
 	// MinRTT is the min RTT measured by BBR in milliseconds.
 	MinRTT float64 `json:"min_rtt"`

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -7,7 +7,7 @@ protocol](https://github.com/ndt-project/ndt). Ndt7 is based on
 WebSocket and TLS, and takes advantage of TCP BBR, where this
 flavour of TCP is available.
 
-This is version v0.6.1 of the ndt7 specification.
+This is version v0.7.0 of the ndt7 specification.
 
 ## Protocol description
 
@@ -134,10 +134,10 @@ structure:
 ```json
 {
   "app_info": {
-    "num_bytes": 17.0,
+    "num_bytes": 17,
   },
   "bbr_info": {
-    "max_bandwidth": 12345.4,
+    "max_bandwidth": 12345,
     "min_rtt": 123.4
   },
   "elapsed": 1.2345,
@@ -153,7 +153,7 @@ Where:
 - `app_info` is an _optional_ JSON object only included in the measurement
   when an application-level measurement is available:
 
-    - `num_bytes` (a `float64`) is the number of bytes sent (or received) since
+    - `num_bytes` (a `int64`) is the number of bytes sent (or received) since
       the beginning of the specific subtest. Note that this counter tracks the
       amount of data sent at application level. It does not account for the
       protocol overheaded of WebSockets, TCP, UDP, IP, and link layer;
@@ -161,7 +161,7 @@ Where:
 - `bbr_info` is an _optional_ JSON object only included in the measurement
   when it is possible to access `TCP_CC_INFO` stats for BBR:
 
-    - `bbr_info.max_bandwidth` (a `float64`) is the max-bandwidth measured by
+    - `bbr_info.max_bandwidth` (a `int64`) is the max-bandwidth measured by
        BBR, in bits per second;
 
     - `bbr_info.min_rtt` (a `float64`) is the min-rtt measured by BBR,
@@ -176,10 +176,7 @@ Where:
 
     - `tcp_info.rtt_var` (a `float64`) is RTT variance in milliseconds;
 
-    - `tcp_info.smoothed_Rtt` (a `float64`) is the smoothed RTT in milliseconds.
-
-The reason why we always use `float64` (i.e. `double`) for numeric variables is
-that this allows also 32 bit systems to handle such variables easily.
+    - `tcp_info.smoothed_rtt` (a `float64`) is the smoothed RTT in milliseconds.
 
 # Reference implementation
 

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -75,15 +75,23 @@ WebSocket messages, binary WebSocket messages carrying a random payload;
 the receiver (i.e. the client during a download subtest) MUST discard
 these messages without processing them.
 
-As far as textual and binary messages are concerned, ndt7 subtests are
+As far as binary messages are concerned, ndt7 subtests are strictly
 half duplex. During the download, the client MUST NOT send any binary
-or textual message to the server. During the upload, the server MUST NOT
-send any binary or textual message to the client.
+message to the server. During the upload, the server MUST NOT send
+any binary message to the client. If a party receives a binary message
+when that is not expected, it MUST close the connection.
 
-Control messages, on the other hand, are always allowed. Ping messages,
-specifically, SHOULD NOT be sent more frequently than one every 250
-millisecond. A party receiving too frequent ping messages MAY decide
-to close the connection.
+All other messages are permitted. Implementations should be prepared
+to receive such messages during any subtest. Processing these messages
+isn't mandatory and an implementation MAY choose to ignore them. An
+implementation SHOULD NOT send this kind of messages more frequently
+than every 250 millisecond. An implementation MAY close the connection
+if receiving such messages too frequently. The reason why we allow
+this kind of messages is so that the server could sent to the client
+download speed measurements during the upload test. This provides
+clients that do not have BBR support with a reasonably good estimation
+of the real upload speed, which is certainly more informative and
+stable than any application level sender side estimation.
 
 The expected transfer time of each subtest is ten seconds (unless BBR
 is used, in which case it may be shorter, as explained below). The sender

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -156,7 +156,7 @@ Where:
     - `num_bytes` (a `int64`) is the number of bytes sent (or received) since
       the beginning of the specific subtest. Note that this counter tracks the
       amount of data sent at application level. It does not account for the
-      protocol overheaded of WebSockets, TCP, UDP, IP, and link layer;
+      protocol overheaded of WebSockets, TLS, TCP, IP, and link layer;
 
 - `bbr_info` is an _optional_ JSON object only included in the measurement
   when it is possible to access `TCP_CC_INFO` stats for BBR:

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -178,6 +178,12 @@ Where:
 
     - `tcp_info.smoothed_rtt` (a `float64`) is the smoothed RTT in milliseconds.
 
+Note that JSON and JavaScript actually define integers as `int53` but existing
+implementations will likely round bigger (or smaller) numbers to the nearest
+`float64` value. A pedantic implementation MAY want to be overly defensive and
+make sure that it does not mit values that a `int53` cannot represent. The
+proper action to take in this case is currently unspecified.
+
 # Reference implementation
 
 The reference implementation is [github.com/m-lab/ndt-server](


### PR DESCRIPTION
It makes sense to use float64 where the measurement unit is
a floating, but using it when we're sending integer quantities
is actually a bit surprising.

While it's true that `float64` is native to the i386 platform
and `int64` it's not, I don't even know whether `int64` is slower
than `float64` and, even if that was the case, it would probably
be weird anyway to use `float64` rather than `int64`.

Another reason why I was using `float64` is that I didn't know
how to extact `int64`s from C code. But C code is gone in the
previous commit. Conclusion: let's use `int64` instead.

Now, why `int64` and not `uint64`? The different is subtle. We
know that in many cases golang is using signed integers also
for sizes, so that is not so surprising in golang. In Java there
is no unsigned, so in theory I could say I am doing this for
the sake of good old Java. The reality is that JSON cannot really
serialize numbers larger than 2^53 as integers, therefore the
distinction betwwn `int64` and `uint64` here is academic. Thus,
I have picked the most natural feat in golang.

(Should I check for overflow? In theory. In practice I think we
are good for quite some years without checking for overflow of
`int64` variables. Also, in the server side there are checks for
overflow of `int64`, but not of `int53`. In the client side I
think we should not care, since that is a minimal client.)

- - -

In addition to the above, there is also a17f14f that reallows
counter-flow messages. Will make upload better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/71)
<!-- Reviewable:end -->
