### PR TITLE
fix(ndt-server.go): make ndt7 work again

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/m-lab/ndt-server/legacy/testresponder"
 	"github.com/m-lab/ndt-server/logging"
 	"github.com/m-lab/ndt-server/metrics"
+	"github.com/m-lab/ndt-server/ndt7/server/listener"
 	"github.com/m-lab/ndt-server/ndt7/server/download"
 	"github.com/m-lab/ndt-server/ndt7/spec"
 
@@ -174,7 +175,7 @@ func main() {
 			Handler: logging.MakeAccessLogHandler(ndt7Mux),
 		}
 		log.Println("About to listen for ndt7 tests on " + *ndt7Port)
-		rtx.Must(httpx.ListenAndServeTLSAsync(ndt7Server, *certFile, *keyFile), "Could not start ndt7 server")
+		rtx.Must(listener.ListenAndServeTLSAsync(ndt7Server, *certFile, *keyFile), "Could not start ndt7 server")
 		defer ndt7Server.Close()
 	} else {
 		log.Printf("Cert=%q and Key=%q means no TLS services will be started.\n", *certFile, *keyFile)


### PR DESCRIPTION
Cherry pick of 27a942d58c5948aea053782720ba48108bb289fd
with the required changes to make it apply cleanly.

With this diff applied, ndt7 works again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/76)
<!-- Reviewable:end -->
