### PR TITLE
Add META test to ndt-server

### DIFF
--- a/legacy/legacy.go
+++ b/legacy/legacy.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
+	cTestMID    = 1
 	cTestC2S    = 2
 	cTestS2C    = 4
+	cTestSFW    = 8
 	cTestStatus = 16
 	cTestMETA   = 32
 )
@@ -162,6 +164,7 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server) {
 	runC2s := (tests & cTestC2S) != 0
 	runS2c := (tests & cTestS2C) != 0
 	runMeta := (tests & cTestMETA) != 0
+	// TODO: count cTestSFW & cTestMID requests.
 
 	if runC2s {
 		testsToRun = append(testsToRun, strconv.Itoa(cTestC2S))

--- a/legacy/legacy.go
+++ b/legacy/legacy.go
@@ -29,6 +29,7 @@ const (
 	cTestC2S    = 2
 	cTestS2C    = 4
 	cTestStatus = 16
+	cTestMETA   = 32
 )
 
 // NDTResult is the struct that is serialized as JSON to disk as the archival record of an NDT test.
@@ -51,9 +52,9 @@ type NDTResult struct {
 
 	StartTime time.Time
 	EndTime   time.Time
-	C2S       *c2s.ArchivalData  `json:",omitempty"`
-	S2C       *s2c.ArchivalData  `json:",omitempty"`
-	Meta      *meta.ArchivalData `json:",omitempty"`
+	C2S       *c2s.ArchivalData `json:",omitempty"`
+	S2C       *s2c.ArchivalData `json:",omitempty"`
+	Meta      meta.ArchivalData `json:",omitempty"`
 }
 
 // SaveData archives the data to disk.
@@ -160,12 +161,16 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server) {
 	testsToRun := []string{}
 	runC2s := (tests & cTestC2S) != 0
 	runS2c := (tests & cTestS2C) != 0
+	runMeta := (tests & cTestMETA) != 0
 
 	if runC2s {
 		testsToRun = append(testsToRun, strconv.Itoa(cTestC2S))
 	}
 	if runS2c {
 		testsToRun = append(testsToRun, strconv.Itoa(cTestS2C))
+	}
+	if runMeta {
+		testsToRun = append(testsToRun, strconv.Itoa(cTestMETA))
 	}
 
 	m := conn.Messager()
@@ -196,6 +201,10 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server) {
 			s2cRate = record.S2C.MeanThroughputMbps
 			metrics.TestRate.WithLabelValues("s2c").Observe(s2cRate)
 		}
+	}
+	if runMeta {
+		record.Meta, err = meta.ManageTest(ctx, m)
+		rtx.PanicOnError(err, "META - Could not run meta test")
 	}
 	speedMsg := fmt.Sprintf("You uploaded at %.4f and downloaded at %.4f", c2sRate*1000, s2cRate*1000)
 	log.Println(speedMsg)

--- a/legacy/meta/meta.go
+++ b/legacy/meta/meta.go
@@ -56,7 +56,6 @@ func collectMeta(m protocol.Messager, c chan *archiveErr) {
 	count := 0
 	for count < maxClientMessages {
 		message, err = m.ReceiveMessage(protocol.TestMsg)
-		// message, err = protocol.ReceiveJSONMessage(m, protocol.TestMsg)
 		if string(message) == "" || err != nil {
 			break
 		}

--- a/legacy/meta/meta.go
+++ b/legacy/meta/meta.go
@@ -58,6 +58,10 @@ func ManageTest(ctx context.Context, m protocol.Messager) (ArchivalData, error) 
 		}
 		results[name] = value
 	}
+	if localCtx.Err() != nil {
+		log.Println("META context error:", localCtx.Err())
+		return nil, localCtx.Err()
+	}
 	if err != nil {
 		log.Println("Error reading JSON message:", err)
 		return nil, err

--- a/legacy/meta/meta.go
+++ b/legacy/meta/meta.go
@@ -1,31 +1,84 @@
 package meta
 
 import (
+	"context"
 	"log"
+	"strings"
+	"time"
 
 	"github.com/m-lab/ndt-server/legacy/protocol"
 )
 
-// TODO: Add fields here when we implement a meta test.
-type ArchivalData struct{}
+// maxClientMessages is the maximum allowed messages we will accept from a client.
+var maxClientMessages = 10
 
-// TODO: run meta test.
-func ManageTest(ws protocol.Connection) {
+// NameValue is an individual meta response.
+type NameValue struct {
+	Name  string
+	Value string
+}
+
+// ArchivalData contains all meta data reported by the client.
+type ArchivalData []NameValue
+
+type archiveErr struct {
+	archivalData ArchivalData
+	err          error
+}
+
+// ManageTest runs the meta tests. If the ctx is Done before the meta test is
+// completed, then the given conn is closed and the context error returned.
+func ManageTest(ctx context.Context, m protocol.Messager) (ArchivalData, error) {
+	localCtx, localCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer localCancel()
+
+	c := make(chan *archiveErr)
+	go collectMeta(m, c)
+	defer close(c)
+
+	select {
+	case <-localCtx.Done():
+		return nil, localCtx.Err()
+	case ae := <-c:
+		return ae.archivalData, ae.err
+	}
+}
+
+// collectMeta actually collects the meta data from the client and reports
+// results over the given channel.
+func collectMeta(m protocol.Messager, c chan *archiveErr) {
 	var err error
-	var message *protocol.JSONMessage
+	var message []byte
+	results := []NameValue{}
 
-	protocol.SendJSONMessage(protocol.TestPrepare, "", ws)
-	protocol.SendJSONMessage(protocol.TestStart, "", ws)
-	for {
-		message, err = protocol.ReceiveJSONMessage(ws, protocol.TestMsg)
-		if message.Msg == "" || err != nil {
+	m.SendMessage(protocol.TestPrepare, []byte{})
+	m.SendMessage(protocol.TestStart, []byte{})
+	count := 0
+	for count < maxClientMessages {
+		message, err = m.ReceiveMessage(protocol.TestMsg)
+		// message, err = protocol.ReceiveJSONMessage(m, protocol.TestMsg)
+		if string(message) == "" || err != nil {
 			break
 		}
-		log.Println("Meta message: ", message)
+		count++
+
+		log.Println("Meta message: ", string(message))
+		s := strings.SplitN(string(message), ":", 2)
+		name := s[0]
+		if len(name) > 63 {
+			name = name[:63]
+		}
+		value := s[1]
+		if len(value) > 255 {
+			value = value[:255]
+		}
+		results = append(results, NameValue{Name: name, Value: value})
 	}
 	if err != nil {
 		log.Println("Error reading JSON message:", err)
+		c <- &archiveErr{archivalData: nil, err: err}
 		return
 	}
-	protocol.SendJSONMessage(protocol.TestFinalize, "", ws)
+	m.SendMessage(protocol.TestFinalize, []byte{})
+	c <- &archiveErr{archivalData: results, err: nil}
 }

--- a/legacy/meta/meta_test.go
+++ b/legacy/meta/meta_test.go
@@ -68,9 +68,7 @@ func TestManageTest(t *testing.T) {
 					{msg: []byte("a:b")},
 				},
 			},
-			want: []NameValue{
-				{Name: "a", Value: "b"},
-			},
+			want: map[string]string{"a": "b"},
 		},
 		{
 			name: "truncate-name-to-63-bytes",
@@ -80,9 +78,7 @@ func TestManageTest(t *testing.T) {
 					{msg: append(len64, []byte(":b")...)},
 				},
 			},
-			want: []NameValue{
-				{Name: string(len64[:63]), Value: "b"},
-			},
+			want: map[string]string{string(len64[:63]): "b"},
 		},
 		{
 			name: "truncate-value-to-255-bytes",
@@ -92,9 +88,7 @@ func TestManageTest(t *testing.T) {
 					{msg: append([]byte("a:"), len256...)},
 				},
 			},
-			want: []NameValue{
-				{Name: "a", Value: string(len256[:255])},
-			},
+			want: map[string]string{"a": string(len256[:255])},
 		},
 		{
 			name: "receive-error",
@@ -105,6 +99,16 @@ func TestManageTest(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "skip-bad-key",
+			ctx:  context.Background(),
+			m: &fakeMessager{
+				recv: []recvMessage{
+					{msg: []byte("this-key-has-no-colon-separator")},
+				},
+			},
+			want: map[string]string{},
 		},
 	}
 	for _, tt := range tests {

--- a/legacy/meta/meta_test.go
+++ b/legacy/meta/meta_test.go
@@ -65,9 +65,7 @@ func TestManageTest(t *testing.T) {
 			ctx:  context.Background(),
 			m: &fakeMessager{
 				recv: []recvMessage{
-					{
-						msg: []byte("a:b"),
-					},
+					{msg: []byte("a:b")},
 				},
 			},
 			want: []NameValue{
@@ -79,9 +77,7 @@ func TestManageTest(t *testing.T) {
 			ctx:  context.Background(),
 			m: &fakeMessager{
 				recv: []recvMessage{
-					{
-						msg: append(len64, []byte(":b")...),
-					},
+					{msg: append(len64, []byte(":b")...)},
 				},
 			},
 			want: []NameValue{
@@ -93,9 +89,7 @@ func TestManageTest(t *testing.T) {
 			ctx:  context.Background(),
 			m: &fakeMessager{
 				recv: []recvMessage{
-					{
-						msg: append([]byte("a:"), len256...),
-					},
+					{msg: append([]byte("a:"), len256...)},
 				},
 			},
 			want: []NameValue{
@@ -107,9 +101,7 @@ func TestManageTest(t *testing.T) {
 			ctx:  context.Background(),
 			m: &fakeMessager{
 				recv: []recvMessage{
-					{
-						err: fmt.Errorf("Fake failure to ReceiveMessage"),
-					},
+					{err: fmt.Errorf("Fake failure to ReceiveMessage")},
 				},
 			},
 			wantErr: true,

--- a/legacy/meta/meta_test.go
+++ b/legacy/meta/meta_test.go
@@ -1,0 +1,130 @@
+package meta
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/m-lab/ndt-server/legacy/protocol"
+)
+
+type sendMessage struct {
+	t   protocol.MessageType
+	msg []byte
+}
+type recvMessage struct {
+	msg []byte
+	err error
+}
+type fakeMessager struct {
+	sent []sendMessage
+	recv []recvMessage
+	c    int
+}
+
+func (m *fakeMessager) SendMessage(t protocol.MessageType, msg []byte) error {
+	m.sent = append(m.sent, sendMessage{t: t, msg: msg})
+	return nil
+}
+func (m *fakeMessager) ReceiveMessage(t protocol.MessageType) ([]byte, error) {
+	if len(m.recv) <= m.c {
+		return []byte(""), nil
+	}
+	msg, err := m.recv[m.c].msg, m.recv[m.c].err
+	m.c++
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+func (m *fakeMessager) SendS2CResults(throughputKbps, unsentBytes, totalSentBytes int64) error {
+	// Unused.
+	return nil
+}
+func (m *fakeMessager) Encoding() protocol.Encoding {
+	// Unused.
+	return protocol.JSON
+}
+
+var len32 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")
+var len64 = append(len32, len32...)
+var len128 = append(len64, len64...)
+var len256 = append(len128, len128...)
+
+func TestManageTest(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		m       protocol.Messager
+		want    ArchivalData
+		wantErr bool
+	}{
+		{
+			name: "success",
+			ctx:  context.Background(),
+			m: &fakeMessager{
+				recv: []recvMessage{
+					{
+						msg: []byte("a:b"),
+					},
+				},
+			},
+			want: []NameValue{
+				{Name: "a", Value: "b"},
+			},
+		},
+		{
+			name: "truncate-name-to-63-bytes",
+			ctx:  context.Background(),
+			m: &fakeMessager{
+				recv: []recvMessage{
+					{
+						msg: append(len64, []byte(":b")...),
+					},
+				},
+			},
+			want: []NameValue{
+				{Name: string(len64[:63]), Value: "b"},
+			},
+		},
+		{
+			name: "truncate-value-to-255-bytes",
+			ctx:  context.Background(),
+			m: &fakeMessager{
+				recv: []recvMessage{
+					{
+						msg: append([]byte("a:"), len256...),
+					},
+				},
+			},
+			want: []NameValue{
+				{Name: "a", Value: string(len256[:255])},
+			},
+		},
+		{
+			name: "receive-error",
+			ctx:  context.Background(),
+			m: &fakeMessager{
+				recv: []recvMessage{
+					{
+						err: fmt.Errorf("Fake failure to ReceiveMessage"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ManageTest(tt.ctx, tt.m)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ManageTest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ManageTest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/legacy/protocol/protocol.go
+++ b/legacy/protocol/protocol.go
@@ -104,7 +104,7 @@ var badUUID = "ERROR_DISCOVERING_UUID"
 // UUIDToFile converts a UUID into a newly-created open file with the extension '.json'.
 func UUIDToFile(dir, uuid string) (*os.File, error) {
 	if uuid == badUUID {
-		f, err := ioutil.TempFile(dir, badUUID+"XXXXXX.json")
+		f, err := ioutil.TempFile(dir, badUUID+"*.json")
 		if err != nil {
 			log.Println("Could not create filename for data")
 			return nil, err


### PR DESCRIPTION
This change adds support to the META test for all client types.

The NDT meta protocol does not specify a limit on the number of values a client may send to the server. This PR sets the limit to 10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/121)
<!-- Reviewable:end -->
