### PR TITLE
Provide clients with the four tuple and the UUID

### DIFF
--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -21,7 +21,7 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn))
+	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultsfp))
 	receiverch := receiver.Start(wholectx, conn)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -21,7 +21,7 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultsfp))
+	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp))
 	receiverch := receiver.Start(wholectx, conn)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/download/measurer/measurer.go
+++ b/ndt7/download/measurer/measurer.go
@@ -76,7 +76,7 @@ func loop(
 				Elapsed: elapsed.Seconds(),
 			}
 			measure(&measurement, sockfp)
-			if !sentConnectionInfo {
+			if sentConnectionInfo == false {
 				measurement.ConnectionInfo = &model.ConnectionInfo{
 					Client: conn.RemoteAddr().String(),
 					Server: conn.LocalAddr().String(),

--- a/ndt7/download/measurer/measurer.go
+++ b/ndt7/download/measurer/measurer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/m-lab/ndt-server/fdcache"
 	"github.com/m-lab/ndt-server/logging"
 	"github.com/m-lab/ndt-server/ndt7/model"
+	"github.com/m-lab/ndt-server/ndt7/results"
 	"github.com/m-lab/ndt-server/ndt7/spec"
 	"github.com/m-lab/ndt-server/tcpinfox"
 )
@@ -45,7 +46,10 @@ func measure(measurement *model.Measurement, sockfp *os.File) {
 	}
 }
 
-func loop(ctx context.Context, conn *websocket.Conn, dst chan<- model.Measurement) {
+func loop(
+	ctx context.Context, conn *websocket.Conn, resultsfp *results.File,
+	dst chan<- model.Measurement,
+) {
 	logging.Logger.Debug("measurer: start")
 	defer logging.Logger.Debug("measurer: stop")
 	defer close(dst)
@@ -60,6 +64,7 @@ func loop(ctx context.Context, conn *websocket.Conn, dst chan<- model.Measuremen
 	t0 := time.Now()
 	ticker := time.NewTicker(spec.MinMeasurementInterval)
 	defer ticker.Stop()
+	sentConnectionInfo := false
 	for {
 		select {
 		case <-measurerctx.Done(): // Liveness!
@@ -71,6 +76,14 @@ func loop(ctx context.Context, conn *websocket.Conn, dst chan<- model.Measuremen
 				Elapsed: elapsed.Seconds(),
 			}
 			measure(&measurement, sockfp)
+			if !sentConnectionInfo {
+				measurement.ConnectionInfo = &model.ConnectionInfo{
+					Client: conn.RemoteAddr().String(),
+					Server: conn.LocalAddr().String(),
+					UUID:   "urn:mlab:" + resultsfp.UUID,
+				}
+				sentConnectionInfo = true
+			}
 			dst <- measurement // Liveness: this is blocking
 		}
 	}
@@ -82,8 +95,10 @@ func loop(ctx context.Context, conn *websocket.Conn, dst chan<- model.Measuremen
 // Liveness guarantee: the measurer will always terminate after
 // a timeout of DefaultRuntime seconds, provided that the consumer
 // continues reading from the returned channel.
-func Start(ctx context.Context, conn *websocket.Conn) <-chan model.Measurement {
+func Start(
+	ctx context.Context, conn *websocket.Conn, resultsfp *results.File,
+) <-chan model.Measurement {
 	dst := make(chan model.Measurement)
-	go loop(ctx, conn, dst)
+	go loop(ctx, conn, resultsfp, dst)
 	return dst
 }

--- a/ndt7/model/connectioninfo.go
+++ b/ndt7/model/connectioninfo.go
@@ -1,0 +1,13 @@
+package model
+
+// ConnectionInfo contains connection info.
+type ConnectionInfo struct {
+	// Client is the client endpoint
+	Client string `json:"client"`
+
+	// Server is the server endpoint
+	Server string `json:"server"`
+
+	// UUID is the internal unique identifier of this experiment.
+	UUID string `json:"uuid"`
+}

--- a/ndt7/model/measurement.go
+++ b/ndt7/model/measurement.go
@@ -3,14 +3,17 @@ package model
 // The Measurement struct contains measurement results. This structure is
 // meant to be serialised as JSON as sent as a textual message.
 type Measurement struct {
-	// Elapsed is the number of seconds elapsed since the beginning.
-	Elapsed float64 `json:"elapsed"`
-
 	// AppInfo contains application level measurements.
 	AppInfo *AppInfo `json:"app_info,omitempty"`
 
+	// ConnectionInfo contains connection information.
+	ConnectionInfo *ConnectionInfo `json:"connection_info,omitempty"`
+
 	// BBRInfo is the data measured using TCP BBR instrumentation.
 	BBRInfo *BBRInfo `json:"bbr_info,omitempty"`
+
+	// Elapsed is the number of seconds elapsed since the beginning.
+	Elapsed float64 `json:"elapsed"`
 
 	// TCPInfo contains metrics measured using TCP_INFO instrumentation.
 	TCPInfo *TCPInfo `json:"tcp_info,omitempty"`

--- a/ndt7/results/file.go
+++ b/ndt7/results/file.go
@@ -22,6 +22,9 @@ type File struct {
 
 	// Fp is the underlying file
 	Fp *os.File
+
+	// UUID is the UUID of this subtest
+	UUID string
 }
 
 // newFile opens a measurements file in the current working
@@ -48,6 +51,7 @@ func newFile(datadir, what, uuid string) (*File, error) {
 	return &File{
 		Writer: writer,
 		Fp:     fp,
+		UUID:   uuid,
 	}, nil
 }
 

--- a/ndt7/saver/saver.go
+++ b/ndt7/saver/saver.go
@@ -102,9 +102,7 @@ func SaveAll(resultfp *results.File, serverch, clientch <-chan model.Measurement
 		// We don't want to save connection_info on the server side because that's
 		// just convenience information provided to the client that is already
 		// duplicated into the "header" that we add as first line of a results file.
-		if imsg.m.ConnectionInfo != nil {
-			imsg.m.ConnectionInfo = nil
-		}
+		imsg.m.ConnectionInfo = nil
 		if err := resultfp.WriteMeasurement(imsg.m, imsg.o); err != nil {
 			logging.Logger.WithError(err).Warn(
 				"saver: resultfp.WriteMeasurement failed",

--- a/ndt7/saver/saver.go
+++ b/ndt7/saver/saver.go
@@ -99,6 +99,12 @@ func SaveAll(resultfp *results.File, serverch, clientch <-chan model.Measurement
 	logging.Logger.Debug("saver: start")
 	defer logging.Logger.Debug("saver: stop")
 	for imsg := range zipch {
+		// We don't want to save connection_info on the server side because that's
+		// just convenience information provided to the client that is already
+		// duplicated into the "header" that we add as first line of a results file.
+		if imsg.m.ConnectionInfo != nil {
+			imsg.m.ConnectionInfo = nil
+		}
 		if err := resultfp.WriteMeasurement(imsg.m, imsg.o); err != nil {
 			logging.Logger.WithError(err).Warn(
 				"saver: resultfp.WriteMeasurement failed",

--- a/spec/data-format.md
+++ b/spec/data-format.md
@@ -4,7 +4,7 @@ This specification describes how ndt-server serializes ndt7 data
 on disk. Other implementations of the ndt7 protocol MAY use other
 data serialization formats.
 
-This is version v0.1.0 of the data-format specification.
+This is version v0.2.0 of the data-format specification.
 
 For each subtest, ndt7 writes on the current working directory a Gzip
 compressed JSONL file (i.e. a file where each line is a JSON). The file
@@ -60,7 +60,8 @@ JSON object containing the following keys:
 
 - `"measurement"`: an `object` containing the fields specified by
   [ndt7-protocol.md](ndt7-protocol.md) in the "Measurements message" section,
-  except that the "padding" (if any) MUST be removed from the measurement.
+  except that a server MAY choose to remove the "connection_info" optional
+  object to avoid storing duplicate information.
 
 A valid measurement JSON could be:
 
@@ -68,11 +69,11 @@ A valid measurement JSON could be:
 {
   "measurement": {
     "bbr_info": {
-      "max_bandwidth": 12345.4,
+      "max_bandwidth": 12345,
       "min_rtt": 123.4
     },
     "elapsed": 1.2345,
-    "num_bytes": 17.0,
+    "num_bytes": 17,
     "tcp_info": {
       "rtt_var": 123.4,
       "smoothed_rtt": 567.8

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -7,7 +7,7 @@ protocol](https://github.com/ndt-project/ndt). Ndt7 is based on
 WebSocket and TLS, and takes advantage of TCP BBR, where this
 flavour of TCP is available.
 
-This is version v0.7.0 of the ndt7 specification.
+This is version v0.7.1 of the ndt7 specification.
 
 ## Protocol description
 
@@ -144,6 +144,11 @@ structure:
   "app_info": {
     "num_bytes": 17,
   },
+  "connection_info": {
+    "client": "1.2.3.4:5678",
+    "server": "[::1]:2345",
+    "uuid": "urn:<platform>:<platform-specific-string>"
+  },
   "bbr_info": {
     "max_bandwidth": 12345,
     "min_rtt": 123.4
@@ -165,6 +170,26 @@ Where:
       the beginning of the specific subtest. Note that this counter tracks the
       amount of data sent at application level. It does not account for the
       protocol overheaded of WebSockets, TLS, TCP, IP, and link layer;
+
+- `connection_info` is an _optional_ JSON object that the server SHOULD
+  provide as part of the first measurement message sent to clients to
+  inform them about:
+
+    - `client` (a `string`), which contains the serialization of the client
+      endpoint according to the server. Note that the general format of
+      this field is `<address>:<port>` where IPv4 addresses are provided
+      verbatim, while IPv6 addresses are quoted by `[` and `]` as shown
+      in the above example;
+
+    - `server` (a `string`), which contains the serialization of the server
+      endpoint according to the server, following the same general format
+      specified above for the client `field`;
+
+    - `uuid` (a `string`), which contains an internal unique identifier
+      for this test within the Measurement Lab platform, following the
+      following format `urn:<platform>:<platform-specific-string>` where
+      the `mlab` string is reserved for tests run in the Measurement
+      Lab platform.
 
 - `bbr_info` is an _optional_ JSON object only included in the measurement
   when it is possible to access `TCP_CC_INFO` stats for BBR:


### PR DESCRIPTION
Addresses #123 and #124 for ndt7. Unclear if further action is required for the legacy protocol at this stage. If not, we should probably close the relevant issues when this is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/126)
<!-- Reviewable:end -->
