### PR TITLE
Add new monitoring for requested tests and submitted meta values

### DIFF
--- a/legacy/legacy.go
+++ b/legacy/legacy.go
@@ -167,7 +167,7 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server) {
 	runSFW := (tests & cTestSFW) != 0
 	runMID := (tests & cTestMID) != 0
 
-	legacymetrics.ClientRequestedTestSuites.WithLabelValues(fmt.Sprintf("0x%02x", 0xff&tests)).Inc()
+	legacymetrics.ClientRequestedTestSuites.WithLabelValues(fmt.Sprintf("%d", 0xff&tests)).Inc()
 
 	if runMID {
 		legacymetrics.ClientRequestedTests.WithLabelValues("mid").Inc()

--- a/legacy/legacy.go
+++ b/legacy/legacy.go
@@ -167,6 +167,8 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server) {
 	runSFW := (tests & cTestSFW) != 0
 	runMID := (tests & cTestMID) != 0
 
+	legacymetrics.ClientRequestedTestSuites.WithLabelValues(fmt.Sprintf("0x%02x", 0xff&tests)).Inc()
+
 	if runMID {
 		legacymetrics.ClientRequestedTests.WithLabelValues("mid").Inc()
 	}

--- a/legacy/legacy.go
+++ b/legacy/legacy.go
@@ -164,16 +164,26 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server) {
 	runC2s := (tests & cTestC2S) != 0
 	runS2c := (tests & cTestS2C) != 0
 	runMeta := (tests & cTestMETA) != 0
-	// TODO: count cTestSFW & cTestMID requests.
+	runSFW := (tests & cTestSFW) != 0
+	runMID := (tests & cTestMID) != 0
 
+	if runMID {
+		legacymetrics.ClientRequestedTests.WithLabelValues("mid").Inc()
+	}
 	if runC2s {
 		testsToRun = append(testsToRun, strconv.Itoa(cTestC2S))
+		legacymetrics.ClientRequestedTests.WithLabelValues("c2s").Inc()
 	}
 	if runS2c {
 		testsToRun = append(testsToRun, strconv.Itoa(cTestS2C))
+		legacymetrics.ClientRequestedTests.WithLabelValues("s2c").Inc()
+	}
+	if runSFW {
+		legacymetrics.ClientRequestedTests.WithLabelValues("sfw").Inc()
 	}
 	if runMeta {
 		testsToRun = append(testsToRun, strconv.Itoa(cTestMETA))
+		legacymetrics.ClientRequestedTests.WithLabelValues("meta").Inc()
 	}
 
 	m := conn.Messager()

--- a/legacy/meta/meta.go
+++ b/legacy/meta/meta.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/m-lab/ndt-server/legacy/metrics"
 	"github.com/m-lab/ndt-server/legacy/protocol"
 )
 
 // maxClientMessages is the maximum allowed messages we will accept from a client.
-// TODO: add histogram (1-20) counting number of messages per client.
 var maxClientMessages = 20
 
 // ArchivalData contains all meta data reported by the client.
@@ -43,7 +43,6 @@ func ManageTest(ctx context.Context, m protocol.Messager) (ArchivalData, error) 
 		}
 		count++
 
-		log.Println("Meta message: ", string(message))
 		s := strings.SplitN(string(message), ":", 2)
 		if len(s) != 2 {
 			continue
@@ -66,6 +65,8 @@ func ManageTest(ctx context.Context, m protocol.Messager) (ArchivalData, error) 
 		log.Println("Error reading JSON message:", err)
 		return nil, err
 	}
+	// Count the number meta values sent by the client (when there are no errors).
+	metrics.SubmittedMetaValues.Observe(float64(count))
 	m.SendMessage(protocol.TestFinalize, []byte{})
 	return results, nil
 }

--- a/legacy/metrics/metrics.go
+++ b/legacy/metrics/metrics.go
@@ -41,4 +41,20 @@ var (
 			Help: "The number of times we sniffed-then-proxied a websocket connection on the legacy channel.",
 		},
 	)
+	ClientRequestedTests = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt_legacy_client_requested_tests_total",
+			Help: "The number of client requests for each legacy test type.",
+		},
+		[]string{"type"},
+	)
+	SubmittedMetaValues = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "ndt_legacy_submitted_meta_values",
+			Help: "The number of meta values submitted by clients.",
+			Buckets: []float64{
+				0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+				11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+		},
+	)
 )

--- a/legacy/metrics/metrics.go
+++ b/legacy/metrics/metrics.go
@@ -41,6 +41,13 @@ var (
 			Help: "The number of times we sniffed-then-proxied a websocket connection on the legacy channel.",
 		},
 	)
+	ClientRequestedTestSuites = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt_legacy_client_requested_suites_total",
+			Help: "The number of client request test suites (the combination of all test types as an integer 0-255).",
+		},
+		[]string{"suite"},
+	)
 	ClientRequestedTests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ndt_legacy_client_requested_tests_total",

--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -152,8 +152,10 @@ func Test_MainIntegrationTest(t *testing.T) {
 	tests := []testcase{
 		// Legacy TLV-only clients.
 		{
+			// NOTE: we must disable the middle-box test in the legacy TLV client because it unconditionally expects
+			// that test to run irrespective of what the server supports.
 			name: "web100clt (legacy TLV)",
-			cmd:  "timeout 45s /bin/web100clt-without-json-support --name localhost --port " + legacyAddr + " --disablemid --disablesfw",
+			cmd:  "timeout 45s /bin/web100clt-without-json-support --name localhost --port " + legacyAddr + " --disablemid",
 		},
 		{
 			name: "libndt-client - legacy NDT with JSON, download test",
@@ -193,7 +195,7 @@ func Test_MainIntegrationTest(t *testing.T) {
 		// Test legacy raw JSON clients
 		{
 			name: "web100clt (with JSON), no MID or SFW",
-			cmd:  "timeout 45s /bin/web100clt-with-json-support --name localhost --port " + legacyAddr + " --disablemid --disablesfw",
+			cmd:  "timeout 45s /bin/web100clt-with-json-support --name localhost --port " + legacyAddr,
 		},
 		// Test legacy WS clients connected to the HTTP port
 		{


### PR DESCRIPTION
The current legacy implementation does not include active sfw and mid tests. When a client requests specific test types, the server may optionally return only the supported tests that the client ought to respect.

This change adds monitoring to observe how often we have clients requesting the sfw and mid tests. 

As well, this change removes options from the PLAIN,TLV and PLAIN,JSON test clients where unnecessary and where necessary document the reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/128)
<!-- Reviewable:end -->
