### PR TITLE
add go vet etl to check etl dependencies

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,10 @@ set -ex
 # Test the NDT binary
 PATH=${PATH}:${GOPATH}/bin
 
+# Check that we haven't blatently broken etl dependencies.
+go get -t github.com/m-lab/etl/...
+go vet github.com/m-lab/etl/...
+
 # If we aren't running on Travis, then there's no need to produce a coverage
 # file and submit it to coveralls.io
 if [[ -z ${TRAVIS_PULL_REQUEST} ]]; then


### PR DESCRIPTION
etl now depends on ndt-server.  This adds go vet on the etl repo to ensure we don't break it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/146)
<!-- Reviewable:end -->
