### PR TITLE
Check for nil connection after timeout

### DIFF
--- a/ndt5/singleserving/server.go
+++ b/ndt5/singleserving/server.go
@@ -187,6 +187,9 @@ func (ps *plainServer) ServeOnce(ctx context.Context) (protocol.MeasuredConnecti
 	if err != nil {
 		return nil, err
 	}
+	if conn == nil {
+		return nil, errors.New("nil conn, nil err: " + derivedCtx.Err().Error())
+	}
 	return protocol.AdaptNetConn(conn, conn), nil
 }
 


### PR DESCRIPTION
Previously, the PlainServer could return an invalid protocol.MeasuredConnection when the context timed out, for instance, as a result of a client that never connected to an S2C or C2S test server.

The invalid MeasuredConnection instance caused panics that resulted in the server SIGSEGV https://github.com/m-lab/ndt-server/issues/153

This change detects and returns an error when the `conn == nil`.

Closes #153 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/154)
<!-- Reviewable:end -->
