### PR TITLE
ndt7/measurer yak shaving

### DIFF
--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -21,7 +21,7 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp))
+	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
 	receiverch := receiver.StartDownloadReceiver(wholectx, conn)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -76,7 +76,6 @@ func (h Handler) downloadOrUpload(writer http.ResponseWriter, request *http.Requ
 	if err != nil {
 		return // error already printed
 	}
-
 	// Collect test metadata.
 	// NOTE: unless we plan to run the NDT server over different protocols than TCP,
 	// then we expect RemoteAddr and LocalAddr to always return net.TCPAddr types.
@@ -97,10 +96,12 @@ func (h Handler) downloadOrUpload(writer http.ResponseWriter, request *http.Requ
 		ServerPort:     serverAddr.Port,
 		StartTime:      time.Now(),
 	}
+	resultfp.StartTest()
 	// Guarantee that we record an end time, even if tester panics.
 	defer func() {
 		// TODO(m-lab/ndt-server/issues/152): Simplify interface between result.File and data.NDTResult.
 		result.EndTime = time.Now()
+		resultfp.EndTest()
 		if kind == spec.SubtestDownload {
 			result.Download = resultfp.Data
 		} else if kind == spec.SubtestUpload {
@@ -113,7 +114,6 @@ func (h Handler) downloadOrUpload(writer http.ResponseWriter, request *http.Requ
 		}
 		warnonerror.Close(resultfp, string(kind)+": ignoring resultfp.Close error")
 	}()
-
 	tester(request.Context(), conn, resultfp)
 }
 

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -67,7 +67,11 @@ func loop(
 	defer resultsfp.EndTest()
 	ticker := time.NewTicker(spec.MinMeasurementInterval)
 	defer ticker.Stop()
-	sentConnectionInfo := false
+	connectionInfo := &model.ConnectionInfo{
+		Client: conn.RemoteAddr().String(),
+		Server: conn.LocalAddr().String(),
+		UUID:   resultsfp.Data.UUID,
+	}
 	for {
 		select {
 		case <-measurerctx.Done(): // Liveness!
@@ -79,14 +83,8 @@ func loop(
 				Elapsed: elapsed.Seconds(),
 			}
 			measure(&measurement, sockfp)
-			if sentConnectionInfo == false {
-				measurement.ConnectionInfo = &model.ConnectionInfo{
-					Client: conn.RemoteAddr().String(),
-					Server: conn.LocalAddr().String(),
-					UUID:   resultsfp.Data.UUID,
-				}
-				sentConnectionInfo = true
-			}
+			measurement.ConnectionInfo = connectionInfo
+			connectionInfo = nil
 			dst <- measurement // Liveness: this is blocking
 		}
 	}

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -62,7 +62,7 @@ func loop(
 		return
 	}
 	defer sockfp.Close()
-	t0 := time.Now()
+	start := time.Now()
 	resultsfp.StartTest()
 	defer resultsfp.EndTest()
 	ticker := time.NewTicker(spec.MinMeasurementInterval)
@@ -74,7 +74,7 @@ func loop(
 	}
 	for measurerctx.Err() == nil { // Liveness!
 		now := <-ticker.C
-		elapsed := now.Sub(t0)
+		elapsed := now.Sub(start)
 		measurement := model.Measurement{
 			Elapsed: elapsed.Seconds(),
 		}

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -72,21 +72,16 @@ func loop(
 		Server: conn.LocalAddr().String(),
 		UUID:   resultsfp.Data.UUID,
 	}
-	for {
-		select {
-		case <-measurerctx.Done(): // Liveness!
-			logging.Logger.Debug("measurer: context done")
-			return
-		case now := <-ticker.C:
-			elapsed := now.Sub(t0)
-			measurement := model.Measurement{
-				Elapsed: elapsed.Seconds(),
-			}
-			measure(&measurement, sockfp)
-			measurement.ConnectionInfo = connectionInfo
-			connectionInfo = nil
-			dst <- measurement // Liveness: this is blocking
+	for measurerctx.Err() == nil { // Liveness!
+		now := <-ticker.C
+		elapsed := now.Sub(t0)
+		measurement := model.Measurement{
+			Elapsed: elapsed.Seconds(),
 		}
+		measure(&measurement, sockfp)
+		measurement.ConnectionInfo = connectionInfo
+		connectionInfo = nil
+		dst <- measurement // Liveness: this is blocking
 	}
 }
 

--- a/ndt7/upload/upload.go
+++ b/ndt7/upload/upload.go
@@ -21,7 +21,7 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp))
+	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
 	receiverch := receiver.StartUploadReceiver(wholectx, conn)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }


### PR DESCRIPTION
This is a collection of simplifications developed while I was collecting data useful to quantify the extent of the error caused by sampling BBRInfo every 0.25 seconds.

I suggest to read each individual diff on its own, because each bears a clear rationale and reading each of them in isolation definitely feels more readable.

Because this is a collection of diffs PR, I think we should not squash and merge.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/158)
<!-- Reviewable:end -->
