### PR TITLE
Explicitly close the download test connection after 10sec

### DIFF
--- a/ndt5/ndt5.go
+++ b/ndt5/ndt5.go
@@ -75,6 +75,7 @@ func panicMsgToErrType(msg string) string {
 		"S2C":             {},
 		"MsgResults":      {},
 		"MsgLogout":       {},
+		"META":            {},
 	}
 	words := strings.SplitN(msg, " ", 1)
 	if len(words) >= 1 {

--- a/ndt5/plain/plain.go
+++ b/ndt5/plain/plain.go
@@ -32,7 +32,7 @@ type plainServer struct {
 }
 
 func (ps *plainServer) SingleServingServer(direction string) (ndt.SingleMeasurementServer, error) {
-	return singleserving.ListenPlain()
+	return singleserving.ListenPlain(direction)
 }
 
 // sniffThenHandle implements protocol sniffing to allow WS clients and just-TCP

--- a/ndt5/protocol/protocol.go
+++ b/ndt5/protocol/protocol.go
@@ -133,11 +133,16 @@ type measurer struct {
 	cancelMeasurementContext context.CancelFunc
 }
 
+// StartMeasuring starts a polling measurement goroutine that runs until the ctx
+// expires. After measurement is complete, the given `fd` is closed.
 func (m *measurer) StartMeasuring(ctx context.Context, fd *os.File) {
 	m.measurements = make(chan *web100.Metrics)
 	var newctx context.Context
 	newctx, m.cancelMeasurementContext = context.WithCancel(ctx)
-	go web100.MeasureViaPolling(newctx, fd, m.measurements)
+	go func() {
+		defer fd.Close()
+		web100.MeasureViaPolling(newctx, fd, m.measurements)
+	}()
 }
 
 func (m *measurer) StopMeasuring() (*web100.Metrics, error) {

--- a/ndt5/protocol/protocol.go
+++ b/ndt5/protocol/protocol.go
@@ -177,6 +177,7 @@ func (ws *wsConnection) FillUntil(t time.Time, bytes []byte) (bytesWritten int64
 }
 
 func (ws *wsConnection) StartMeasuring(ctx context.Context) {
+	// Measurer closes the fd returned by GetAndForgetFile.
 	ws.measurer.StartMeasuring(ctx, fdcache.GetAndForgetFile(ws.UnderlyingConn()))
 }
 
@@ -265,6 +266,7 @@ func (nc *netConnection) FillUntil(t time.Time, bytes []byte) (bytesWritten int6
 }
 
 func (nc *netConnection) StartMeasuring(ctx context.Context) {
+	// Measurer closes the fd returned by GetAndForgetFile.
 	nc.measurer.StartMeasuring(ctx, fdcache.GetAndForgetFile(nc))
 }
 

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -111,7 +111,10 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	}
 
 	// Close the test connection to signal to single-threaded clients that the
-	// download has completed.
+	// download has completed. Note: a possible optimisation is to wait for
+	// one-two seconds for the client to close the connection and then close
+	// it anyway. This gives us the advantage that the client will retain
+	// the state assciated with initiating the close.
 	warnonerror.Close(testConn, "Could not close testConnection")
 
 	bps := 8 * float64(byteCount) / 10

--- a/ndt5/singleserving/server.go
+++ b/ndt5/singleserving/server.go
@@ -201,7 +201,7 @@ func (ps *plainServer) ServeOnce(ctx context.Context) (protocol.MeasuredConnecti
 // timeouts) after this returns.
 func ListenPlain(direction string) (ndt.SingleMeasurementServer, error) {
 	ndt5metrics.MeasurementServerStart.WithLabelValues(string(ndt.Plain)).Inc()
-	// Simulate "code" for raw connections to account for all tests.
+	// The "code" label is required for the TestCount metric. The code value is hardcoded.
 	metrics.TestCount.MustCurryWith(prometheus.Labels{"direction": direction, "code": "200"})
 	// Start listening right away to ensure that subsequent connections succeed.
 	s := &plainServer{}

--- a/ndt5/singleserving/server.go
+++ b/ndt5/singleserving/server.go
@@ -199,8 +199,10 @@ func (ps *plainServer) ServeOnce(ctx context.Context) (protocol.MeasuredConnecti
 // will not actually respond until ServeOnce() is called, but the connect() will
 // not fail as long as ServeOnce is called soon ("soon" is defined by os-level
 // timeouts) after this returns.
-func ListenPlain() (ndt.SingleMeasurementServer, error) {
+func ListenPlain(direction string) (ndt.SingleMeasurementServer, error) {
 	ndt5metrics.MeasurementServerStart.WithLabelValues(string(ndt.Plain)).Inc()
+	// Simulate "code" for raw connections to account for all tests.
+	metrics.TestCount.MustCurryWith(prometheus.Labels{"direction": direction, "code": "200"})
 	// Start listening right away to ensure that subsequent connections succeed.
 	s := &plainServer{}
 	l, err := net.Listen("tcp", ":0")

--- a/ndt5/web100/web100_linux.go
+++ b/ndt5/web100/web100_linux.go
@@ -29,6 +29,7 @@ func summarize(snaps []*unix.TCPInfo) (*Metrics, error) {
 // non-BBR connections because MinRTT is one of our critical metrics.
 func MeasureViaPolling(ctx context.Context, fp *os.File, c chan *Metrics) {
 	defer close(c)
+	defer fp.Close()
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	snaps := make([]*unix.TCPInfo, 0, 100)

--- a/ndt5/web100/web100_linux.go
+++ b/ndt5/web100/web100_linux.go
@@ -27,6 +27,7 @@ func summarize(snaps []*unix.TCPInfo) (*Metrics, error) {
 
 // MeasureViaPolling collects all required data by polling. It is required for
 // non-BBR connections because MinRTT is one of our critical metrics.
+// MeasureViaPolling closes `fp` on return.
 func MeasureViaPolling(ctx context.Context, fp *os.File, c chan *Metrics) {
 	defer close(c)
 	defer fp.Close()


### PR DESCRIPTION
Addresses https://github.com/m-lab/ndt-server/issues/160

As part of the fdcache, the server maintains two fds for the same client test connections. Both must be closed for the client to see the connection terminated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/162)
<!-- Reviewable:end -->
