### PR TITLE
Complete removal of close in MeasureViaPolling

### DIFF
--- a/ndt5/web100/web100_linux.go
+++ b/ndt5/web100/web100_linux.go
@@ -27,10 +27,8 @@ func summarize(snaps []*unix.TCPInfo) (*Metrics, error) {
 
 // MeasureViaPolling collects all required data by polling. It is required for
 // non-BBR connections because MinRTT is one of our critical metrics.
-// MeasureViaPolling closes `fp` on return.
 func MeasureViaPolling(ctx context.Context, fp *os.File, c chan *Metrics) {
 	defer close(c)
-	defer fp.Close()
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	snaps := make([]*unix.TCPInfo, 0, 100)


### PR DESCRIPTION
This is a change that I failed to save so didn't get committed in https://github.com/m-lab/ndt-server/pull/162

Without this change, the server should still behave correctly but will attempt to close the fd twice, which should fail harmlessly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/165)
<!-- Reviewable:end -->
