### PR TITLE
Split error message to extract first word

### DIFF
--- a/ndt5/ndt5.go
+++ b/ndt5/ndt5.go
@@ -77,7 +77,7 @@ func panicMsgToErrType(msg string) string {
 		"MsgLogout":       {},
 		"META":            {},
 	}
-	words := strings.SplitN(msg, " ", 1)
+	words := strings.SplitN(msg, " ", 2)
 	if len(words) >= 1 {
 		word := words[0]
 		if _, ok := okayWords[word]; ok {


### PR DESCRIPTION
SplitN was finding at most N fields in the given message, which with a value of 1 always meant "words" == "msg" which always failed to be found in the okayWords map.

With SplitN(2) panicMsgToErrType can correctly extract the first word.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/167)
<!-- Reviewable:end -->
