### PR TITLE
Add measurement-kit to the integration tests

### DIFF
--- a/TestDockerfile
+++ b/TestDockerfile
@@ -13,7 +13,8 @@
 # A base image with some helpful tools and libraries installed.
 FROM golang:1.12-buster AS ndtbuild
 WORKDIR /
-RUN apt-get update && apt-get install -y build-essential autotools-dev automake zlib1g-dev git cmake libssl-dev libcurl4-openssl-dev
+RUN apt-get update && apt-get install -y build-essential autotools-dev \
+    automake zlib1g-dev git cmake libssl-dev libcurl4-openssl-dev
 RUN git clone --recursive https://github.com/m-lab/ndt/
 
 

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -15,7 +15,7 @@ FROM golang:1.12-buster AS ndtbase
 WORKDIR /
 RUN apt-get update && apt-get install -y git libmaxminddb0 libevent-2.1-6 \
     libevent-core-2.1-6 libevent-extra-2.1-6 \
-	libevent-openssl-2.1-6 libevent-pthreads-2.1-6
+    libevent-openssl-2.1-6 libevent-pthreads-2.1-6
 
 
 # A base image for building clients.
@@ -23,7 +23,7 @@ FROM ndtbase AS ndtbuild
 WORKDIR /
 RUN apt-get update && apt-get install -y build-essential autotools-dev \
     automake zlib1g-dev cmake libssl-dev libcurl4-openssl-dev \
-	libmaxminddb-dev libevent-dev libtool-bin libtool
+    libmaxminddb-dev libevent-dev libtool-bin libtool
 RUN git clone --recursive https://github.com/m-lab/ndt/
 
 

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -1,6 +1,19 @@
+# TestDockerfile for running ndt-server integration tests.
+#
+# BUILD STEPS:
+# * Setup a base build environment based on the same image as the final image.
+# * Build libndt, measurement-kit, ndtrawjson, ndtrawnojson clients
+# * Setup the final image by copying clients.
+#
+# Because client binaries are dynamically linked, the versions must be
+# available during build and in the final image. The simplest way to guarantee
+# that is to use the same base image.
+
+
 # A base image with some helpful tools and libraries installed.
-FROM ubuntu AS ndtbuild
-RUN apt-get update && apt-get install -y build-essential autotools-dev automake zlib1g-dev git cmake libssl-dev
+FROM golang:1.12-buster AS ndtbuild
+WORKDIR /
+RUN apt-get update && apt-get install -y build-essential autotools-dev automake zlib1g-dev git cmake libssl-dev libcurl4-openssl-dev
 RUN git clone --recursive https://github.com/m-lab/ndt/
 
 
@@ -10,6 +23,20 @@ RUN git clone --recursive https://github.com/measurement-kit/libndt
 WORKDIR /libndt
 RUN cmake .
 RUN cmake --build .
+
+
+# Build a measurement_kit client.
+FROM ndtbuild AS mk
+RUN apt-get install -y libmaxminddb-dev libmaxminddb0 libevent-dev \
+    libevent-2.1-6 libevent-core-2.1-6 libevent-extra-2.1-6 \
+	libevent-openssl-2.1-6 libevent-pthreads-2.1-6 curl libtool-bin \
+	libtool
+RUN git clone https://github.com/measurement-kit/measurement-kit.git
+WORKDIR /measurement-kit
+RUN ./autogen.sh
+RUN ./configure
+RUN make
+RUN make install
 
 
 # Build a version of web100clt that uses JSON.
@@ -43,12 +70,15 @@ RUN make web100clt
 
 
 # Build the image in which the server will be tested.
-FROM golang:1.12 AS build
+FROM golang:1.12-buster AS build
 COPY --from=ndtrawjson /ndt/src/web100clt /bin/web100clt-with-json-support
 COPY --from=ndtrawnojson /ndt/src/web100clt /bin/web100clt-without-json-support
 COPY --from=libndt /libndt/libndt-client /bin/libndt-client
+COPY --from=mk /usr/local/bin/measurement_kit /bin/measurement_kit
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get update && apt-get install -y nodejs libjansson4 libssl1.1 libssl1.0
+RUN apt-get update && apt-get install -y nodejs libjansson4 libssl1.1 \
+    libssl1.0 libmaxminddb0 libevent-2.1-6 libevent-core-2.1-6 \
+	libevent-extra-2.1-6 libevent-openssl-2.1-6 libevent-pthreads-2.1-6
 ENV GOPATH=/go
 RUN go get github.com/mattn/goveralls
 ADD . /go/src/github.com/m-lab/ndt-server

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -10,11 +10,20 @@
 # that is to use the same base image.
 
 
-# A base image with some helpful tools and libraries installed.
-FROM golang:1.12-buster AS ndtbuild
+# A base image for building and the final image.
+FROM golang:1.12-buster AS ndtbase
+WORKDIR /
+RUN apt-get update && apt-get install -y git libmaxminddb0 libevent-2.1-6 \
+    libevent-core-2.1-6 libevent-extra-2.1-6 \
+	libevent-openssl-2.1-6 libevent-pthreads-2.1-6
+
+
+# A base image for building clients.
+FROM ndtbase AS ndtbuild
 WORKDIR /
 RUN apt-get update && apt-get install -y build-essential autotools-dev \
-    automake zlib1g-dev git cmake libssl-dev libcurl4-openssl-dev
+    automake zlib1g-dev cmake libssl-dev libcurl4-openssl-dev \
+	libmaxminddb-dev libevent-dev libtool-bin libtool
 RUN git clone --recursive https://github.com/m-lab/ndt/
 
 
@@ -28,10 +37,6 @@ RUN cmake --build .
 
 # Build a measurement_kit client.
 FROM ndtbuild AS mk
-RUN apt-get install -y libmaxminddb-dev libmaxminddb0 libevent-dev \
-    libevent-2.1-6 libevent-core-2.1-6 libevent-extra-2.1-6 \
-	libevent-openssl-2.1-6 libevent-pthreads-2.1-6 curl libtool-bin \
-	libtool
 RUN git clone https://github.com/measurement-kit/measurement-kit.git
 WORKDIR /measurement-kit
 RUN ./autogen.sh
@@ -70,16 +75,14 @@ WORKDIR /ndt/src
 RUN make web100clt
 
 
-# Build the image in which the server will be tested.
-FROM golang:1.12-buster AS build
+# Build the final image in which the server will be tested.
+FROM ndtbase AS final
 COPY --from=ndtrawjson /ndt/src/web100clt /bin/web100clt-with-json-support
 COPY --from=ndtrawnojson /ndt/src/web100clt /bin/web100clt-without-json-support
 COPY --from=libndt /libndt/libndt-client /bin/libndt-client
 COPY --from=mk /usr/local/bin/measurement_kit /bin/measurement_kit
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get update && apt-get install -y nodejs libjansson4 libssl1.1 \
-    libssl1.0 libmaxminddb0 libevent-2.1-6 libevent-core-2.1-6 \
-	libevent-extra-2.1-6 libevent-openssl-2.1-6 libevent-pthreads-2.1-6
+RUN apt-get update && apt-get install -y nodejs libjansson4 libssl1.1 libssl1.0
 ENV GOPATH=/go
 RUN go get github.com/mattn/goveralls
 ADD . /go/src/github.com/m-lab/ndt-server

--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -262,6 +262,11 @@ func Test_MainIntegrationTest(t *testing.T) {
 			// Ignore data because Travis does not support BBR.  Once Travis does support BBR, delete this.
 			ignoreData: true,
 		},
+		// Measurement Kit client
+		{
+			name: "measurement_kit testing ndt5 protocol",
+			cmd:  "timeout 45s measurement_kit --no-bouncer --no-collector --no-json --no-geoip ndt -p " + ndt5Addr + " localhost",
+		},
 	}
 
 	go main()


### PR DESCRIPTION
This change adds measurement-kit client to the integration test suite. Previously, it was the only client that reported an error from https://github.com/m-lab/ndt-server/issues/160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/168)
<!-- Reviewable:end -->
