### PR TITLE
Adjusted run network to get NDT5 speed tests working

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ sudo modprobe tcp_bbr
 and run the `ndt-server` binary container
 
 ```bash
-docker run --network=bridge                \
-           --publish 443:4443              \
+docker run --network=host                \
            --volume `pwd`/certs:/certs:ro  \
            --volume `pwd`/datadir:/datadir \
            --read-only                     \
@@ -53,7 +52,7 @@ docker run --network=bridge                \
 
 Once you have done that, you should have a ndt5 server running on ports
 `3001` (legacy binary flavour), `3002` (WebSocket flavour), and `3010`
-(secure WebSocket flavour); a ndt7 server running on port `443` (over TLS
+(secure WebSocket flavour); a ndt7 server running on port `4443` (over TLS
 and using the ndt7 WebSocket protocol); and Prometheus metrics available
 on port `9990`.
 
@@ -62,7 +61,7 @@ appear invalid to your browser, but everything is safe because this is a test
 deployment, hence you should ignore this warning and continue):
 
 * ndt5+wss: https://localhost:3010/static/widget.html
-* ndt7: https://localhost/static/ndt7.html
+* ndt7: https://localhost:4443/static/ndt7.html
 * prometheus: http://localhost:9090/metrics
 
 Replace `localhost` with the IP of the server to access them externally.


### PR DESCRIPTION
I wasn't able to get NDT5 tests working until I switched to using network=host as that exposes all ports bound by the container, not just the explicitly mapped/exposed ports. A side effect is that the service couldn't bind to 443 (possibly caused by the cap drop), updated to use 4443 instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/173)
<!-- Reviewable:end -->
