### PR TITLE
Convert ClientMetadata map types to []metadata.NameValue

### DIFF
--- a/metadata/namevalue.go
+++ b/metadata/namevalue.go
@@ -1,0 +1,7 @@
+package metadata
+
+// NameValue is a BigQuery-compatible type for ClientMetadata "name"/"value" pairs.
+type NameValue struct {
+	Name  string
+	Value string
+}

--- a/ndt5/control/data.go
+++ b/ndt5/control/data.go
@@ -1,7 +1,7 @@
 package control
 
 import (
-	"github.com/m-lab/ndt-server/ndt5/meta"
+	"github.com/m-lab/ndt-server/metadata"
 	"github.com/m-lab/ndt-server/ndt5/ndt"
 )
 
@@ -11,5 +11,5 @@ type ArchivalData struct {
 	UUID            string
 	Protocol        ndt.ConnectionType
 	MessageProtocol string
-	ClientMetadata  meta.ArchivalData `json:",omitempty" bigquery:"-"`
+	ClientMetadata  []metadata.NameValue `json:",omitempty"`
 }

--- a/ndt5/meta/meta_test.go
+++ b/ndt5/meta/meta_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/m-lab/ndt-server/metadata"
 	"github.com/m-lab/ndt-server/ndt5/ndt"
 	"github.com/m-lab/ndt-server/ndt5/protocol"
 )
@@ -72,7 +73,7 @@ func TestManageTest(t *testing.T) {
 		name    string
 		ctx     context.Context
 		m       protocol.Messager
-		want    ArchivalData
+		want    []metadata.NameValue
 		wantErr bool
 	}{
 		{
@@ -83,7 +84,7 @@ func TestManageTest(t *testing.T) {
 					{msg: []byte("a:b")},
 				},
 			},
-			want: map[string]string{"a": "b"},
+			want: []metadata.NameValue{{Name: "a", Value: "b"}},
 		},
 		{
 			name: "truncate-name-to-63-bytes",
@@ -93,7 +94,7 @@ func TestManageTest(t *testing.T) {
 					{msg: append(len64, []byte(":b")...)},
 				},
 			},
-			want: map[string]string{string(len64[:63]): "b"},
+			want: []metadata.NameValue{{Name: string(len64[:63]), Value: "b"}},
 		},
 		{
 			name: "truncate-value-to-255-bytes",
@@ -103,7 +104,7 @@ func TestManageTest(t *testing.T) {
 					{msg: append([]byte("a:"), len256...)},
 				},
 			},
-			want: map[string]string{"a": string(len256[:255])},
+			want: []metadata.NameValue{{Name: "a", Value: string(len256[:255])}},
 		},
 		{
 			name: "receive-error",
@@ -123,7 +124,7 @@ func TestManageTest(t *testing.T) {
 					{msg: []byte("this-key-has-no-colon-separator")},
 				},
 			},
-			want: map[string]string{},
+			want: []metadata.NameValue{},
 		},
 	}
 	for _, tt := range tests {

--- a/ndt7/model/archivaldata.go
+++ b/ndt7/model/archivaldata.go
@@ -1,6 +1,10 @@
 package model
 
-import "time"
+import (
+	"time"
+
+	"github.com/m-lab/ndt-server/metadata"
+)
 
 // ArchivalData saves all instantaneous measurements over the lifetime of a test.
 type ArchivalData struct {
@@ -9,6 +13,5 @@ type ArchivalData struct {
 	EndTime            time.Time
 	ServerMeasurements []Measurement
 	ClientMeasurements []Measurement
-	// TODO(m-lab/ndt-server/issues/151): remove bigquery tag.
-	ClientMetadata map[string]string `json:",omitempty" bigquery:"-"`
+	ClientMetadata     []metadata.NameValue `json:",omitempty"`
 }

--- a/ndt7/results/file.go
+++ b/ndt7/results/file.go
@@ -69,7 +69,7 @@ func newFile(datadir, what, uuid string) (*File, error) {
 // indicate whether this is a spec.SubtestDownload or a spec.SubtestUpload
 // ndt7 measurement.
 func OpenFor(request *http.Request, conn *websocket.Conn, datadir string, what spec.SubtestKind) (*File, error) {
-	meta := make(metadata)
+	meta := make(metadata, 1)
 	netConn := conn.UnderlyingConn()
 	id, err := fdcache.GetUUID(netConn)
 	if err != nil {

--- a/ndt7/results/file.go
+++ b/ndt7/results/file.go
@@ -69,7 +69,7 @@ func newFile(datadir, what, uuid string) (*File, error) {
 // indicate whether this is a spec.SubtestDownload or a spec.SubtestUpload
 // ndt7 measurement.
 func OpenFor(request *http.Request, conn *websocket.Conn, datadir string, what spec.SubtestKind) (*File, error) {
-	meta := make(metadata, 1)
+	meta := make(metadata, 0)
 	netConn := conn.UnderlyingConn()
 	id, err := fdcache.GetUUID(netConn)
 	if err != nil {

--- a/ndt7/results/metadata.go
+++ b/ndt7/results/metadata.go
@@ -4,10 +4,12 @@ package results
 import (
 	"net/url"
 	"regexp"
+
+	meta "github.com/m-lab/ndt-server/metadata"
 )
 
 // metadata contains ndt7 metadata.
-type metadata map[string]string
+type metadata []meta.NameValue
 
 // serverKeyRe is a regexp that matches any server related key.
 var serverKeyRe = regexp.MustCompile("^server_")
@@ -15,10 +17,10 @@ var serverKeyRe = regexp.MustCompile("^server_")
 // initMetadata initializes |*meta| from |values| provided from the original
 // request query string.
 func initMetadata(m *metadata, values url.Values) {
-	for k, v := range values {
-		if matches := serverKeyRe.MatchString(k); matches {
+	for name, values := range values {
+		if matches := serverKeyRe.MatchString(name); matches {
 			continue // We MUST skip variables reserved to the server
 		}
-		(*m)[k] = v[0]
+		*m = append(*m, meta.NameValue{Name: name, Value: values[0]})
 	}
 }


### PR DESCRIPTION
This change eliminates `map[string]string` types from the NDTResult and subfields. As a result, we should be able to use the native NDTResult struct with `bigquery.InferSchema` method. This will greatly simplify the ETL parser code for NDT data.

Part of https://github.com/m-lab/dev-tracker/issues/402

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/176)
<!-- Reviewable:end -->
