### PR TITLE
Adds tcpinfo to web100 export data.

### DIFF
--- a/ndt5/protocol/messager_test.go
+++ b/ndt5/protocol/messager_test.go
@@ -1,11 +1,11 @@
 package protocol
 
 import (
+	"errors"
 	"testing"
-)
 
-func TestAnything(t *testing.T) {
-}
+	"github.com/m-lab/ndt-server/ndt5/web100"
+)
 
 func assertJSONMessagerIsMessager(jm *jsonMessager) {
 	func(m Messager) {}(jm)
@@ -13,4 +13,56 @@ func assertJSONMessagerIsMessager(jm *jsonMessager) {
 
 func assertTLVMessagerIsMessager(tm *tlvMessager) {
 	func(m Messager) {}(tm)
+}
+
+type fakeMessager struct {
+	sentMessages []string
+	errorAfter   int
+}
+
+func (fm *fakeMessager) SendMessage(_ MessageType, msg []byte) error {
+	fm.sentMessages = append(fm.sentMessages, string(msg))
+	if fm.errorAfter > 0 {
+		defer func() { fm.errorAfter-- }()
+		if fm.errorAfter == 1 {
+			return errors.New("Error for testing")
+		}
+	}
+	return nil
+}
+
+func (fm *fakeMessager) SendS2CResults(throughputKbps, unsentBytes, totalSentBytes int64) error {
+	return nil
+}
+
+func (fm *fakeMessager) ReceiveMessage(MessageType) ([]byte, error) { return []byte{}, nil }
+
+func (fm *fakeMessager) Encoding() Encoding {
+	return Unknown
+}
+
+func TestSendMetrics(t *testing.T) {
+	data := &web100.Metrics{}
+	fm := &fakeMessager{}
+	err := SendMetrics(data, fm, "")
+	if err != nil {
+		t.Error("Error should be nil", err)
+	}
+	if len(fm.sentMessages) < 20 {
+		t.Error("Bad messages:", fm)
+	}
+}
+
+func TestSendMetricsWithErrors(t *testing.T) {
+	data := &web100.Metrics{}
+	fm := &fakeMessager{
+		errorAfter: 25,
+	}
+	err := SendMetrics(data, fm, "")
+	if err == nil {
+		t.Error("Error should not be nil", err)
+	}
+	if len(fm.sentMessages) > 30 {
+		t.Error("Bad messages:", fm)
+	}
 }

--- a/ndt5/protocol/messager_test.go
+++ b/ndt5/protocol/messager_test.go
@@ -48,13 +48,20 @@ func TestSendMetrics(t *testing.T) {
 	if err != nil {
 		t.Error("Error should be nil", err)
 	}
-	if len(fm.sentMessages) < 20 {
-		t.Error("Bad messages:", fm)
+	// 73 was chosen because we needed a number that was greater than zero and not
+	// greater than the number of fields in the Metrics struct. This is a moving
+	// target, so we don't want to be too specific and require equality with the
+	// current count. There were a total of 73 fields as of 2019-08-23, so that's a
+	// good lower bound.
+	if len(fm.sentMessages) < 73 {
+		t.Error("Bad messages:", len(fm.sentMessages), fm)
 	}
 }
 
 func TestSendMetricsWithErrors(t *testing.T) {
 	data := &web100.Metrics{}
+	// Erroring after 25 fields means that the error occurs inside the tcpinfo
+	// struct, which exercises both error cases in the recursive function.
 	fm := &fakeMessager{
 		errorAfter: 25,
 	}
@@ -62,7 +69,7 @@ func TestSendMetricsWithErrors(t *testing.T) {
 	if err == nil {
 		t.Error("Error should not be nil", err)
 	}
-	if len(fm.sentMessages) > 30 {
-		t.Error("Bad messages:", fm)
+	if len(fm.sentMessages) > 25 {
+		t.Error("Too many messages sent:", fm)
 	}
 }

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -150,7 +150,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 		// Being unable to parse the number should not be a fatal error, so continue.
 	}
 
-	err = protocol.SendMetrics(web100metrics, m)
+	err = protocol.SendMetrics(web100metrics, m, "")
 	if err != nil {
 		log.Println("Could not SendMetrics", err)
 		metrics.ClientTestErrors.WithLabelValues(connType, "s2c", "SendMetrics").Inc()

--- a/ndt5/web100/web100.go
+++ b/ndt5/web100/web100.go
@@ -3,6 +3,8 @@
 // it only needs to measure once.
 package web100
 
+import "github.com/m-lab/tcp-info/tcp"
+
 // Metrics holds web100 data. According to the NDT5 protocol, each of these
 // metrics is required. That does not mean each is required to be non-zero, but
 // it does mean that the field should be present in any response.
@@ -23,4 +25,5 @@ type Metrics struct {
 
 	// Useful metrics that are not part of the required set.
 	BytesPerSecond float64
+	TCPInfo        tcp.LinuxTCPInfo
 }

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -40,9 +40,9 @@ func measure(measurement *model.Measurement, sockfp *os.File) {
 	if err == nil {
 		measurement.BBRInfo = &bbrinfo
 	}
-	metrics, err := tcpinfox.GetTCPInfo(sockfp)
+	tcpInfo, err := tcpinfox.GetTCPInfo(sockfp)
 	if err == nil {
-		measurement.TCPInfo = &metrics
+		measurement.TCPInfo = model.NewTCPInfo(tcpInfo)
 	}
 }
 

--- a/ndt7/model/tcpinfo.go
+++ b/ndt7/model/tcpinfo.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/m-lab/tcp-info/tcp"
+
 // The TCPInfo struct contains information measured using TCP_INFO.
 type TCPInfo struct {
 	// SmoothedRTT is the smoothed RTT in milliseconds.
@@ -7,4 +9,14 @@ type TCPInfo struct {
 
 	// RTTVar is the RTT variance in milliseconds.
 	RTTVar float64 `json:"rtt_var"`
+}
+
+// NewTCPInfo creates an ndt7 model from the TCPInfo struct returned from the kernel.
+func NewTCPInfo(kernelTCPInfo *tcp.LinuxTCPInfo) *TCPInfo {
+	return &TCPInfo{
+		// TODO(bassosimone): map more metrics. For now we only maps the metrics
+		// that are meaningful to a client to understand the context.
+		SmoothedRTT: float64(kernelTCPInfo.RTT) / 1000.0,    // to msec
+		RTTVar:      float64(kernelTCPInfo.RTTVar) / 1000.0, // to msec
+	}
 }

--- a/tcpinfox/tcpinfox.go
+++ b/tcpinfox/tcpinfox.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"os"
 
-	"github.com/m-lab/ndt-server/ndt7/model"
+	"github.com/m-lab/tcp-info/tcp"
 )
 
 // ErrNoSupport is returned on systems that do not support TCP_INFO.
@@ -13,6 +13,6 @@ var ErrNoSupport = errors.New("TCP_INFO not supported")
 
 // GetTCPInfo measures TCP_INFO metrics using |fp| and returns them. In
 // case of error, instead, an error is returned.
-func GetTCPInfo(fp *os.File) (model.TCPInfo, error) {
+func GetTCPInfo(fp *os.File) (*tcp.LinuxTCPInfo, error) {
 	return getTCPInfo(fp)
 }

--- a/tcpinfox/tcpinfox_stub.go
+++ b/tcpinfox/tcpinfox_stub.go
@@ -5,9 +5,9 @@ package tcpinfox
 import (
 	"os"
 
-	"github.com/m-lab/ndt-server/ndt7/model"
+	"github.com/m-lab/tcp-info/tcp"
 )
 
-func getTCPInfo(*os.File) (model.TCPInfo, error) {
-	return model.TCPInfo{}, ErrNoSupport
+func getTCPInfo(*os.File) (*tcp.LinuxTCPInfo, error) {
+	return &tcp.LinuxTCPInfo{}, ErrNoSupport
 }


### PR DESCRIPTION
Lays the groundwork for eliminating quantization by using the existing measurement system to track bytes received.

Lays the groundwork for future simulation of legacy data entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/177)
<!-- Reviewable:end -->
