### PR TITLE
spec/ndt7: address several outstanding issues

### DIFF
--- a/spec/data-format.md
+++ b/spec/data-format.md
@@ -57,8 +57,8 @@ Valid JSON metadata object in ClientMetadata could look like this:
 
 ```JSON
 {
-  "client_library_name":"libndt7.js",
-  "client_library_version":"0.4"
+  "ClientLibraryName": "libndt7.js",
+  "ClientLibraryVersion": "0.4"
 }
 ```
 
@@ -69,21 +69,16 @@ represent individual measurements recorded by the client or server.
 
 A measurement is a JSON object containing the fields specified by
 [ndt7-protocol.md](ndt7-protocol.md) in the "Measurements message" section,
-except that a server MAY choose to remove the "connection_info" optional
+except that a server MAY choose to remove the "ConnectionInfo" optional
 object to avoid storing duplicate information.
 
 A valid measurement JSON could be:
 
 ```JSON
 {
-  "bbr_info": {
-    "max_bandwidth": 12345,
-    "min_rtt": 123.4
-  },
-  "elapsed": 1.2345,
-  "tcp_info": {
-    "rtt_var": 123.4,
-    "smoothed_rtt": 567.8
+  "AppInfo": {
+    "ElapsedTime": 1234,
+    "NumBytes": 1234
   }
 }
 ```

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -42,10 +42,11 @@ also provide kernel-level information from `TCP_INFO` where available. For
 all these reasons we say that ndt7 performs application-level measurements.
 
 The presence of network issues (e.g. interference or congestion) should
-cause ndt7 to yield "bad" measurement results, where bad is implicitly
-defined by comparison to the maximum theoretical speed of the
-end-to-end connection (often times the Wi-Fi or landline data-link
-bitrate). Extra information obtained using `TCP_INFO` should help an expert
+cause ndt7 to yield worse measurement results, relative to the expected speed
+of the end-to-end connection. The expected speed of a BBR connection on an
+unloaded network is the bitrate of the slowest hop in the measurement
+path, and the slowest hop is usually also the last hop.
+Extra information obtained using `TCP_INFO` should help an expert
 reading the results of a ndt7 experiment to better understand what could
 be the root cause of such performance issues.
 

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -320,13 +320,11 @@ implementation of ndt7. A client MAY use other fields, but the absence of
 those fields in a server response MUST NOT be a fatal client error.
 
 The `TCP_INFO` variables returned by this specification are supported by the
-Linux kernel used by M-Lab, which is >= 4.19. In the event in which a ndt-server
-implementation is deployed on older kernels, the server implementation SHOULD
-NOT include into the returned `TCPInfo` object variables that are not supported
-by the kernel being used. If the server is running on an operating system
-that does not support `TCP_INFO`, or if it is not otherwise possible to gather
-`TCP_INFO` information, the `TCPInfo` object SHOULD NOT be included into the
-measurement message.
+Linux kernel used by M-Lab, which is >= 4.19. To protect against the fact that
+an older kernel may not define all the variables, an implementation SHOULD
+initialize the `struct tcp_info` passed to the kernel such that every variable
+value is `-1`, e.g. using `memset(buff, 0xff, sizeof(buf))`. A client SHOULD
+be ready to ignore the variables having such sentinel values.
 
 Moreover, note that all the variables presented above increase or otherwise
 change consistently during a test. Therefore, the most recent measurement sample

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -319,8 +319,14 @@ specification are REQUIRED to be returned by a compliant, `TCP_INFO` enabled
 implementation of ndt7. A client MAY use other fields, but the absence of
 those fields in a server response MUST NOT be a fatal client error.
 
-Also note that some kernels may not support all the above mentioned `TCP_INFO`
-variables. In such case, the unsupported variables SHOULD be set to zero.
+The `TCP_INFO` variables returned by this specification are supported by the
+Linux kernel used by M-Lab, which is >= 4.19. In the event in which a ndt-server
+implementation is deployed on older kernels, the server implementation SHOULD
+NOT include into the returned `TCPInfo` object variables that are not supported
+by the kernel being used. If the server is running on an operating system
+that does not support `TCP_INFO`, or if it is not otherwise possible to gather
+`TCP_INFO` information, the `TCPInfo` object SHOULD NOT be included into the
+measurement message.
 
 Moreover, note that all the variables presented above increase or otherwise
 change consistently during a test. Therefore, the most recent measurement sample

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -35,11 +35,11 @@ a measurement of your last mile speed. Rather it is a measurement
 of what performance is possible with your device, your current internet
 connection (landline, Wi-Fi, 4G, etc.), the characteristics of
 your ISP and possibly of other ISPs in the middle, and the server
-being used. Also, the main measurement performed by ndt7 does not include
-by default overheads such as the WebSocket, the TLS, the TCP/IP, and
-the link layer headers (even though we also provide kernel-level information
-where `TCP_INFO` is available). For all these reasons we say that ndt7
-performs application-level measurements.
+being used. The main metric measured by ndt7 is the goodput, i.e.,
+the speed measured at application level, without including the
+overheads of WebSockets, TLS, TCP/IP, and link layer headers. But we
+also provide kernel-level information from `TCP_INFO` where available. For
+all these reasons we say that ndt7 performs application-level measurements.
 
 The presence of network issues (e.g. interference or congestion) should
 cause ndt7 to yield "bad" measurement results, where bad is implicitly

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -17,9 +17,16 @@ Ndt7 measures the application-level download and upload performance
 using WebSockets over TLS. Each test type is independent, and
 there are two types of test: the download and the upload tests. Ndt7
 always uses a single TCP connection. Whenever possible, ndt7 uses a recent
-version of TCP BBR. Writing a ndt7 client should always be easy. A minimal
-ndt7 client should consist of only a few hundred lines of code in most
-languages (not counting library dependencies, unit and integration tests).
+version of TCP BBR. Writing an ndt7 client is designed to be as simple
+as possible. [A complete Go language ndt7 client](
+https://github.com/bassosimone/ndt7-client-go-minimal) has been implemented
+in just 151 lines. We used 26 lines for the download, 33 for the upload, and
+17 for establishing a connections. No code from the NDT server has been
+reused. [A complete JavaScript client](
+https://github.com/bassosimone/ndt7-server-go-minimal/tree/master/static)
+has been implemented in just 122 lines (32 for the download, 51 for the
+upload, and 39 for controlling the maximum test duration). It is a design
+goal of ndt7 that the size of a minimal client remains small over time.
 
 Ndt7 answers the question of how fast you could pull/push data
 from your device to a typically-nearby, well-provisioned web

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -148,7 +148,7 @@ test, the client sends binary messages and the server MUST NOT send
 them. An implementation receiving a binary message when it is not expected
 SHOULD close the underlying TLS connection.
 
-Binary messages SHOULD contain between 1 << 10 and 1 << 24 bytes, and
+Binary messages MUST contain between 1 << 10 and 1 << 24 bytes, and
 SHOULD be a power of two. An implementation SHOULD initially be sending
 binary messages containing 1 << 13 bytes, and it
 MAY change the size of such messages to accommodate for fast clients, as
@@ -158,8 +158,8 @@ change the message size.
 The expected duration of a test is _up to_ ten seconds. If a test has
 been running for at least thirteen seconds, an implementation MAY close the
 underlying TLS connection. This is allowed to keep the overall duration
-of each test within a thirteen-seconds upper bound. Ideally this SHOULD
-be implemented so that immediately after thirteen-seconds have elapsed, the
+of each test within a thirteen second upper bound. Ideally this SHOULD
+be implemented so that immediately after thirteen seconds have elapsed, the
 underlying TLS connection is closed. This can be implemented, e.g., in C/C++
 using alarm(3) to cause pending I/O operations to fail with `EINTR`.
 
@@ -180,7 +180,7 @@ and SHOULD be recorded into the results. For robustness, we do not
 want such events to cause a whole test to fail. This provision
 gives the ndt7 protocol bizantine robustness, and acknowledges the
 fact that the web is messy and a test may terminate more abruptly
-than it used to happen in our controlled experiments.
+than it happened in the past in our controlled experiments.
 
 ### Measurement message
 
@@ -188,7 +188,7 @@ As mentioned above, the server and the client exchange JSON measurements
 using textual WebSocket messages. The purpose of these measurements is to
 provide information useful to diagnose performance issues.
 
-While in theory we could specify all TCP_INFO and BBR_INFO variables,
+While in theory we could specify all `TCP_INFO` and `BBR_INFO` variables,
 different kernel versions provide different subsets of these measurements
 and we do not want to be needlessly restrictive regarding the underlying
 kernel for the server. Instead, 
@@ -262,7 +262,7 @@ Where:
     - `UUID` (a `string`), which contains an internal unique identifier
       for this test within the Measurement Lab (M-Lab) platform. This field
       SHOULD be omitted by servers running on other platforms, unless they
-      also have the concept of an UUID bound to a TCP connection.
+      also have the concept of a UUID bound to a TCP connection.
 
 - `Origin` is an _optional_ `string` that indicates whether the measurement
   has been performed by the client or by the server. This field SHOULD
@@ -276,55 +276,56 @@ Where:
 - `TCPInfo` is an _optional_ `object` only included in the measurement
   when it is possible to access `TCP_INFO` stats. It contains:
 
-    - `BusyTime` aka `tcpi_busy_time` (a `int64`), i.e. the number of
+    - `BusyTime` aka `tcpi_busy_time` (an _optional_ `int64`), i.e. the number of
        microseconds spent actively sending data because the write queue
        of the TCP socket is non-empty.
 
-    - `BytesAcked` aka `tcpi_bytes_acked` (a `int64`), i.e. the number
+    - `BytesAcked` aka `tcpi_bytes_acked` (an _optional_ `int64`), i.e. the number
       of bytes for which we received acknowledgment. Note that this field,
       and all other `TCPInfo` fields, contain the number of bytes measured
       at TCP/IP level (i.e. including the WebSocket and TLS overhead).
 
-    - `BytesReceived` aka `tcpi_bytes_received` (a `int64`), i.e. the number
+    - `BytesReceived` aka `tcpi_bytes_received` (an _optional_ `int64`), i.e. the number
       of bytes for which we sent acknowledgment.
 
-    - `BytesSent` aka `tcpi_bytes_sent` (a `int64`), i.e. the number of bytes
+    - `BytesSent` aka `tcpi_bytes_sent` (an _optional_ `int64`), i.e. the number of bytes
       which have been transmitted _or_ retransmitted.
 
-    - `BytesRetrans` aka `tcpi_bytes_retrans` (a `int64`), i.e. the number
+    - `BytesRetrans` aka `tcpi_bytes_retrans` (an _optional_ `int64`), i.e. the number
       of bytes which have been retransmitted.
 
-    - `ElapsedTime` (a `int64`), i.e. the time elapsed since the beginning of
+    - `ElapsedTime` (an _optional_ `int64`), i.e. the time elapsed since the beginning of
       this test, measured in microseconds.
 
-    - `MinRTT` aka `tcpi_min_rtt` (a `int64`), i.e. the minimum RTT seen
+    - `MinRTT` aka `tcpi_min_rtt` (an _optional_ `int64`), i.e. the minimum RTT seen
        by the kernel, measured in microseconds.
 
-    - `RTT` aka `tcpi_rtt` (a `int64`), i.e. the current smoothed RTT
+    - `RTT` aka `tcpi_rtt` (an _optional_ `int64`), i.e. the current smoothed RTT
       value, measured in microseconds.
 
-    - `RTTVar` aka `tcpi_rtt_var` (a `int64`), i.e. the variance or `RTT`.
+    - `RTTVar` aka `tcpi_rtt_var` (an _optional_ `int64`), i.e. the variance or `RTT`.
 
-    - `RWndLimited` aka `tcpi_rwnd_limited` (a `int64`), i.e. the amount
+    - `RWndLimited` aka `tcpi_rwnd_limited` (an _optional_ `int64`), i.e. the amount
       of microseconds spent stalled because there is not enough
       buffer at the receiver.
 
-    - `SndBufLimited` aka `tcpi_sndbuf_limited` (a `int64`), i.e. the amount
+    - `SndBufLimited` aka `tcpi_sndbuf_limited` (an _optional_ `int64`), i.e. the amount
       of microseconds spent stalled because there is not enough buffer at
       the sender.
 
 Note that the JSON exchanged on the wire, or saved on disk, MAY possibly
 contain more `TCP_INFO` fields. Yet, only the fields described in this
-specification are REQUIRED to be returned by a compliant, `TCP_INFO` enabled
+specification SHOULD BE returned by a compliant, `TCP_INFO` enabled
 implementation of ndt7. A client MAY use other fields, but the absence of
-those fields in a server response MUST NOT be a fatal client error.
+those other fields in a server response MUST NOT be a fatal client error.
 
-The `TCP_INFO` variables returned by this specification are supported by the
-Linux kernel used by M-Lab, which is >= 4.19. To protect against the fact that
-an older kernel may not define all the variables, an implementation SHOULD
-initialize the `struct tcp_info` passed to the kernel such that every variable
-value is `-1`, e.g. using `memset(buff, 0xff, sizeof(buf))`. A client SHOULD
-be ready to ignore the variables having such sentinel values.
+The `TCP_INFO` variables mentioned by this specification are supported by the
+Linux kernel used by M-Lab, which is >= 4.19. An implementation running on
+a kernel where a specific `TCP_INFO` variable mentioned in this specification
+is missing SHOULD NOT include such variable in the `TCPInfo` object sent to
+the client. In this regard, clients should be robust to missing data. Missing
+data SHOULD NOT cause a client to crash, although it is allowable for it to
+cause an inferior user experience.
 
 Moreover, note that all the variables presented above increase or otherwise
 change consistently during a test. Therefore, the most recent measurement sample

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -16,7 +16,7 @@ This is version v0.8.0 of the ndt7 specification.
 Ndt7 measures the application-level download and upload performance
 using WebSockets over TLS. Each test type is independent, and
 there are two types of test: the download and the upload tests. Ndt7
-always uses a single TCP connection. Where possible, ndt7 uses a recent
+always uses a single TCP connection. Whenever possible, ndt7 uses a recent
 version of TCP BBR. Writing a ndt7 client should always be easy. A minimal
 ndt7 client should consist of only a few hundred lines of code in most
 languages (not counting library dependencies, unit and integration tests).


### PR DESCRIPTION
This modification of the ndt7 spec is non backward compatible
therefore I have bumped the version accordingly.

When reading the spec after this changes have been applied, I am now
confident that we can make a first public release soon.

The following list describes what changed:

1. bumped the version number

2. added a non-normative section describing the design choices of
   ndt7 as recently discussed with @pboothe and @mattmathis

3. reorganized the protocol description to group handshake-related
   information and websocket related information

4. [API CHANGE] now the client MUST include an user-agent
   during the websocket handshake

5. [API CHANGE] removed ambiguity on how the server SHOULD process
   query string keys without a value: now the server SHOULD consider
   them like keys with an empty string as value

6. [API CHANGE] do not force the server to use `400` to indicate
   handshake failure, be relaxed and use `4xx`

7. [API CHANGE] now the server MUST parse the query string

8. [API CHANGE] now the server MUST store the query string

9. reword the section where we describe usage of binary and textual
   websocket messages

10. [API CHANGE] say that implementations SHOULD follow the websocket
    RFC but concede that what they really MUST do is to be robust
    with respect to receiving errors once the test is started. This
    allows us to implement protections such that the duration of a
    test is precise as well as to allow servers to arbitrarily stop
    a transfer earlier than ten seconds if they need that.

11. [API CHANGE] switch to CamelCase for the measurement message

12. [API CHANGE] only document the minimum set of `TCP_INFO` variables
    that seem useful to OONI or Asurion and explicitly say that any
    other variable that MAY be there may disappear without notice

13. [API CHANGE] use natural kernel measurement units, e.g. bytes and
    microsecond, and do that consistently across the structure

14. [API CHANGE] clarify ConnectionInfo and add some extra optional
    fields the Go client was already using so that it will not conflict
    with future variables with same name and different semantics

15. add a section with an explicit example describing the messages
    exchanged both when there are and there are not measurement messages

16. clarify in mlab-ns section that we'll perform A/B testing and that
    implementing a client compatible with the specification is good
    precisely because it gives us flexibility in that respect

17. improve the example code describing exponential backoff to clearly
    indicate that exponential backoff is only to be done when mlabns
    returns the no-content signal

18. improve the reference implementations section to mention that
    simplified clients exist in this repository and to clarify that
    their main purpose is to test against this server

19. write an appendix section that is non normative and mention (1)
    the algorithm proposed by @pboothe for scaling the message size and
    (2) how the `TCP_INFO` variables included into this specification
    could be useful to people.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/180)
<!-- Reviewable:end -->
