### PR TITLE
Add a timeout to prevent slow-clients causing goroutine leaks

### DIFF
--- a/ndt5/plain/plain_test.go
+++ b/ndt5/plain/plain_test.go
@@ -34,7 +34,7 @@ func TestNewPlainServer(t *testing.T) {
 			_, err = w.Write([]byte("test"))
 		}
 		if err == nil {
-			t.Error("We expected a write error but it weas nil")
+			t.Error("We expected a write error but it was nil")
 		}
 	})
 	wsSrv := &http.Server{


### PR DESCRIPTION
* Add a timeout to prevent slow-clients causing goroutine leaks
* Always close the connection when returning from `sniffThenHandle`

Fixes https://github.com/m-lab/ndt-server/issues/117
Part of https://github.com/m-lab/dev-tracker/issues/412

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/184)
<!-- Reviewable:end -->
