### PR TITLE
UUIDs are now in tmpfiles

### DIFF
--- a/fullstack/start.sh
+++ b/fullstack/start.sh
@@ -45,7 +45,12 @@ mkdir -p "${DATA_DIR}"/tcpinfo
   --prometheusx.listen-address=:9991 \
   --uuid-prefix-file="${UUID_FILE}" \
   --output="${DATA_DIR}"/tcpinfo \
+  --eventsocket=/var/local/tcpeventsocket.sock \
   &
+
+while [[ ! -e /var/local/tcpeventsocket.sock ]]; do
+  sleep 1
+done
 
 # Start the traceroute service.
 mkdir -p "${DATA_DIR}"/traceroute
@@ -53,6 +58,7 @@ mkdir -p "${DATA_DIR}"/traceroute
   --prometheusx.listen-address=:9992 \
   --uuid-prefix-file="${UUID_FILE}" \
   --outputPath="${DATA_DIR}"/traceroute \
+  --tcpinfo.socket=/var/local/tcpeventsocket.sock \
   &
 
 # TODO: Start the packet header capture service.

--- a/fullstack/start.sh
+++ b/fullstack/start.sh
@@ -28,9 +28,7 @@ set -euxo pipefail
 
 # Set up UUIDs to have a common race-free prefix.
 UUID_FILE=$(mktemp /tmp/uuidprefix.XXXXXX)
-if [ ! -f "$UUID_FILE" ]; then
-    /create-uuid-prefix-file --filename="${UUID_FILE}"
-fi
+/create-uuid-prefix-file --filename="${UUID_FILE}"
 
 # Set up the data directory.
 DATA_DIR=/var/spool/ndt

--- a/fullstack/start.sh
+++ b/fullstack/start.sh
@@ -27,9 +27,7 @@ set -euxo pipefail
 # Set up the filesystem.
 
 # Set up UUIDs to have a common race-free prefix.
-UUID_DIR=/var/local/uuid
-UUID_FILE=${UUID_DIR}/prefix
-mkdir -p "${UUID_DIR}"
+UUID_FILE=$(mktemp /tmp/uuidprefix.XXXXXX)
 if [ ! -f "$UUID_FILE" ]; then
     /create-uuid-prefix-file --filename="${UUID_FILE}"
 fi


### PR DESCRIPTION
After some thought last night, I realized we moved the codebase in the wrong direction.  Instead, the UUID prefix should be in a file in `/tmp` and be recreated on every run.  Keeping the old file around puts the uniqueness of the UUIDs at risk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/213)
<!-- Reviewable:end -->
