### PR TITLE
Fix timeout at the end of S2C tests

### DIFF
--- a/ndt5/web100/web100_linux.go
+++ b/ndt5/web100/web100_linux.go
@@ -33,9 +33,9 @@ func summarize(snaps []*tcp.LinuxTCPInfo) (*Metrics, error) {
 	info := &Metrics{
 		TCPInfo: *snaps[len(snaps)-1], // Save the last snapshot of TCPInfo data into the metric struct.
 
-		MinRTT:   minrtt / 1000, // tcpinfo is microsecond data, web100 needs milliseconds
-		MaxRTT:   maxrtt / 1000, // tcpinfo is microsecond data, web100 needs milliseconds
-		SumRTT:   sumrtt / 1000, // tcpinfo is microsecond data, web100 needs milliseconds
+		MinRTT: minrtt / 1000, // tcpinfo is microsecond data, web100 needs milliseconds
+		MaxRTT: maxrtt / 1000, // tcpinfo is microsecond data, web100 needs milliseconds
+		SumRTT: sumrtt / 1000, // tcpinfo is microsecond data, web100 needs milliseconds
 
 		CountRTT: countrtt, // This counts how many samples went into SumRTT
 
@@ -53,6 +53,7 @@ func summarize(snaps []*tcp.LinuxTCPInfo) (*Metrics, error) {
 
 func measureUntilContextCancellation(ctx context.Context, fp *os.File) (*Metrics, error) {
 	ticker := time.NewTicker(100 * time.Millisecond)
+	defer fp.Close()
 	defer ticker.Stop()
 
 	snaps := make([]*tcp.LinuxTCPInfo, 0, 200) // Enough space for 20 seconds of data.

--- a/ndt5/web100/web100_linux.go
+++ b/ndt5/web100/web100_linux.go
@@ -53,6 +53,8 @@ func summarize(snaps []*tcp.LinuxTCPInfo) (*Metrics, error) {
 
 func measureUntilContextCancellation(ctx context.Context, fp *os.File) (*Metrics, error) {
 	ticker := time.NewTicker(100 * time.Millisecond)
+	// We need to make sure fp is closed when the polling loop ends to ensure legacy
+	// clients work. See https://github.com/m-lab/ndt-server/issues/160.
 	defer fp.Close()
 	defer ticker.Stop()
 


### PR DESCRIPTION
This PR adds a `defer fp.Close()` in the `measureUntilContextCancellation` func so that the connection gets closed when the context is cancelled. At some point in the past that `Close()` was removed (https://github.com/m-lab/ndt-server/pull/179), it's unclear to me why.
 
This should fix the timeout some clients are intermittently experiencing at the end of a S2C test. While some clients are robust enough to ignore the timeout, others are currently failing.

Hopefully fixes https://github.com/ooni/probe/issues/877 once released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/218)
<!-- Reviewable:end -->
