### PR TITLE
Add concurrent connection limits to NDT server

### DIFF
--- a/TestDockerfile
+++ b/TestDockerfile
@@ -11,7 +11,7 @@
 
 
 # A base image for building and the final image.
-FROM golang:1.12-buster AS ndtbase
+FROM golang:1.13-buster AS ndtbase
 WORKDIR /
 RUN apt-get update && apt-get install -y git libmaxminddb0 libevent-2.1-6 \
     libevent-core-2.1-6 libevent-extra-2.1-6 \

--- a/access/controller.go
+++ b/access/controller.go
@@ -1,0 +1,28 @@
+package access
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// MaxController controls the total number of clients that may run simultaneously.
+// May be used on handlers for multiple servers.
+type MaxController struct {
+	Max     int64
+	Current int64
+}
+
+// Limit enforces the Concurrent Max limit while running the next handler.
+func (c *MaxController) Limit(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := atomic.AddInt64(&c.Current, 1)
+		defer atomic.AddInt64(&c.Current, -1)
+		if c.Max > 0 && cur > c.Max {
+			// 503 - https://tools.ietf.org/html/rfc7231#section-6.6.4
+			w.WriteHeader(http.StatusServiceUnavailable)
+			// Return without additional response.
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/access/controller_test.go
+++ b/access/controller_test.go
@@ -1,0 +1,51 @@
+package access
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMaxController_Limit(t *testing.T) {
+	tests := []struct {
+		name    string
+		Max     int64
+		Current int64
+		want    bool
+		status  int
+	}{
+		{
+			name:   "succes",
+			Max:    0,
+			want:   true,
+			status: http.StatusOK,
+		},
+		{
+			name:    "rejected",
+			Max:     1,
+			Current: 1,
+			want:    false,
+			status:  http.StatusServiceUnavailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &MaxController{
+				Max:     tt.Max,
+				Current: tt.Current,
+			}
+			visited := false
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				visited = true
+			})
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rw := httptest.NewRecorder()
+
+			c.Limit(next).ServeHTTP(rw, req)
+
+			if visited != tt.want {
+				t.Errorf("MaxController.Limit() got %t, want %t", visited, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new `access.MaxController` that when enabled, will allow up to `Max` connections. Default is disabled.

This simple connection limiter is applied to all service ports: 3001 (ws/raw), 3010 (wss), and 443 (ndt7). And, the connection limiter is not applied to the metrics server. Meaning that even under load, the server should remain monitorable.

In time, the "Controller" interface can be extended to support access_tokens, and individual client rate limiting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/231)
<!-- Reviewable:end -->
