### PR TITLE
Saving websocket RTT samples

### DIFF
--- a/data/result.go
+++ b/data/result.go
@@ -45,4 +45,5 @@ type NDTResult struct {
 	// ndt7
 	Upload   *model.ArchivalData `json:",omitempty"`
 	Download *model.ArchivalData `json:",omitempty"`
+	Ping	 *model.ArchivalData `json:",omitempty"`
 }

--- a/html/ndt7-ping.js
+++ b/html/ndt7-ping.js
@@ -1,0 +1,22 @@
+/* jshint esversion: 6, asi: true, worker: true */
+// WebWorker that runs the ndt7 ping test
+onmessage = function (ev) {
+  'use strict'
+  let url = new URL(ev.data.href)
+  url.protocol = (url.protocol === 'https:') ? 'wss:' : 'ws:'
+  url.pathname = '/ndt/v7/ping'
+  const sock = new WebSocket(url.toString(), 'net.measurementlab.ndt.v7')
+  sock.onclose = function () {
+    postMessage(null)
+  }
+  sock.onopen = function () {
+    sock.onmessage = function (ev) {
+      if (!(ev.data instanceof Blob)) {
+        let m = JSON.parse(ev.data)
+        m.Origin = 'server'
+        m.Test = 'ping'
+        postMessage(m)
+      }
+    }
+  }
+}

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -24,8 +24,10 @@
 </head>
 <body>
   <div>
+    <div id='ping' class='result row'>[Ping]</div>
     <div id='download' class='result row'>[Download]</div>
     <div id='upload' class='result row'>[Upload]</div>
+    <div id='done' class='result row'></div>
   </div>
   <script type='text/javascript'>
     /* jshint esversion: 6, asi: true */
@@ -54,12 +56,24 @@
         if (ev === 'complete') {
           if (callback !== undefined) {
             callback()
+          } else {
+            withElementDo('done', function (elem) {
+              elem.innerHTML = 'Done.'
+            })
           }
           return
         }
         if (ev === 'measurement' && val.AppInfo !== undefined &&
             val.Origin === 'client') {
           updateView(testName, val.AppInfo)
+        }
+        if (ev === 'measurement' && val.AppInfo !== undefined &&
+            val.Origin === 'server' && testName === 'ping') {
+          withElementDo('ping', function (elem) {
+            const ws = val.AppInfo.MinRTT / 1e3
+            const tcp = val.TCPInfo.MinRTT / 1e3
+            elem.innerHTML = ws.toFixed(1) + ' / ' + tcp.toFixed(1) + ' ms'
+          })
         }
       })
     }
@@ -72,7 +86,11 @@
       runSomething('upload', callback)
     }
 
-    runDownload(function() { runUpload(); })
+    function runPing(callback) {
+      runSomething('ping', callback)
+    }
+
+    runPing(function() { runDownload(function() { runUpload(); }); })
   </script>
 </body>
 </html>

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -51,6 +51,8 @@
     }
 
     function runSomething(testName, callback) {
+      let ws = Number.NaN;
+      let tcp = Number.NaN;
       ndt7core.run(location.href, testName, function(ev, val) {
         console.log(ev, val)
         if (ev === 'complete') {
@@ -67,12 +69,15 @@
             val.Origin === 'client') {
           updateView(testName, val.AppInfo)
         }
-        if (ev === 'measurement' && val.AppInfo !== undefined &&
-            val.Origin === 'server' && testName === 'ping') {
+        if (ev === 'measurement' && val.Origin === 'server' && testName === 'ping') {
+          if (val.WSInfo !== undefined) {
+            ws = val.WSInfo.MinRTT / 1e3
+          }
+          if (val.TCPInfo !== undefined) {
+            tcp = val.TCPInfo.MinRTT / 1e3
+          }
           withElementDo('ping', function (elem) {
-            const ws = val.AppInfo.MinRTT / 1e3
-            const tcp = val.TCPInfo.MinRTT / 1e3
-            elem.innerHTML = ws.toFixed(1) + ' / ' + tcp.toFixed(1) + ' ms'
+            elem.innerHTML = '⓻ ' + ws.toFixed(1) + ' / ⓸ ' + tcp.toFixed(1) + ' ms'
           })
         }
       })

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -159,6 +159,7 @@ func main() {
 		}
 		ndt7Mux.Handle(spec.DownloadURLPath, http.HandlerFunc(ndt7Handler.Download))
 		ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))
+		ndt7Mux.Handle(spec.PingURLPath, http.HandlerFunc(ndt7Handler.Ping))
 		ndt7Server := &http.Server{
 			Addr:    *ndt7Addr,
 			Handler: logging.MakeAccessLogHandler(ndt7Mux),

--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -23,8 +23,8 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File, start
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	receiverch, rttch := receiver.StartDownloadReceiver(wholectx, conn, start)
-	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start, rttch)
-	senderch := sender.Start(conn, measurerch, start)
+	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start)
+	receiverch, pongch := receiver.StartDownloadReceiver(wholectx, conn, start, measurerch)
+	senderch := sender.Start(conn, measurerch, start, pongch)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -3,6 +3,7 @@ package download
 
 import (
 	"context"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/ndt-server/ndt7/download/sender"
@@ -15,13 +16,15 @@ import (
 // Do implements the download subtest. The ctx argument is the parent
 // context for the subtest. The conn argument is the open WebSocket
 // connection. The resultfp argument is the file where to save results. Both
-// arguments are owned by the caller of this function.
-func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
+// arguments are owned by the caller of this function. The start argument is
+// the test start time used to calculate ElapsedTime and deadlines.
+func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File, start time.Time) {
 	// Implementation note: use child context so that, if we cannot save the
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
-	receiverch := receiver.StartDownloadReceiver(wholectx, conn)
+	receiverch, rttch := receiver.StartDownloadReceiver(wholectx, conn, start)
+	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start, rttch)
+	senderch := sender.Start(conn, measurerch, start)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/download/sender/sender.go
+++ b/ndt7/download/sender/sender.go
@@ -50,6 +50,11 @@ func loop(
 		logging.Logger.WithError(err).Warn("sender: conn.SetWriteDeadline failed")
 		return
 	}
+	// only the first RTT sample taken before flooding the conn is not affected by HOL
+	if err := ping.SendTicks(conn, start, deadline); err != nil {
+		logging.Logger.WithError(err).Warn("sender: ping.SendTicks failed")
+		return
+	}
 	var totalSent int64
 	for {
 		select {

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -39,7 +39,7 @@ func getSocketAndPossiblyEnableBBR(conn *websocket.Conn) (*os.File, error) {
 func measure(measurement *model.Measurement, sockfp *os.File, elapsed time.Duration) {
 	// Implementation note: we always want to sample BBR before TCPInfo so we
 	// will know from TCPInfo if the connection has been closed.
-	t := elapsed.Microseconds()
+	t := int64(elapsed / time.Microsecond)
 	bbrinfo, err := bbr.GetMaxBandwidthAndMinRTT(sockfp)
 	if err == nil {
 		bbrinfo.ElapsedTime = t

--- a/ndt7/model/appinfo.go
+++ b/ndt7/model/appinfo.go
@@ -5,6 +5,4 @@ package model
 type AppInfo struct {
 	NumBytes    int64
 	ElapsedTime int64
-	LastRTT 	int64
-	MinRTT		int64
 }

--- a/ndt7/model/appinfo.go
+++ b/ndt7/model/appinfo.go
@@ -5,4 +5,6 @@ package model
 type AppInfo struct {
 	NumBytes    int64
 	ElapsedTime int64
+	LastRTT 	int64
+	MinRTT		int64
 }

--- a/ndt7/model/measurement.go
+++ b/ndt7/model/measurement.go
@@ -8,4 +8,5 @@ type Measurement struct {
 	ConnectionInfo *ConnectionInfo `json:",omitempty" bigquery:"-"`
 	BBRInfo        *BBRInfo        `json:",omitempty"`
 	TCPInfo        *TCPInfo        `json:",omitempty"`
+	WSInfo         *WSInfo	       `json:",omitempty"`
 }

--- a/ndt7/model/wsinfo.go
+++ b/ndt7/model/wsinfo.go
@@ -1,0 +1,10 @@
+package model
+
+// WSInfo contains an application level (websocket) ping measurement data.
+// It may be melded into AppInfo.
+// FIXME: describe this structure is in the ndt7 specification.
+type WSInfo struct {
+    ElapsedTime int64
+    LastRTT     int64 // TCPInfo.RTT is smoothed RTT, LastRTT is just a sample.
+    MinRTT      int64
+}

--- a/ndt7/ping/ping.go
+++ b/ndt7/ping/ping.go
@@ -9,10 +9,8 @@ import (
 )
 
 // SendTicks sends the current ticks as a ping message.
-func SendTicks(conn *websocket.Conn, deadline time.Time) error {
-	// TODO(bassosimone): when we'll have a unique base time.Time reference for
-	// the whole test, we should use that, since UnixNano() is not monotonic.
-	ticks := int64(time.Now().UnixNano())
+func SendTicks(conn *websocket.Conn, start time.Time, deadline time.Time) error {
+	var ticks int64 = time.Since(start).Nanoseconds()
 	data, err := json.Marshal(ticks)
 	if err == nil {
 		err = conn.WriteControl(websocket.PingMessage, data, deadline)
@@ -20,13 +18,12 @@ func SendTicks(conn *websocket.Conn, deadline time.Time) error {
 	return err
 }
 
-func ParseTicks(s string) (d int64, err error) {
-	// TODO(bassosimone): when we'll have a unique base time.Time reference for
-	// the whole test, we should use that, since UnixNano() is not monotonic.
+func ParseTicks(s string, start time.Time) (d time.Duration, err error) {
+	elapsed := time.Since(start).Nanoseconds()
 	var prev int64
 	err = json.Unmarshal([]byte(s), &prev)
-	if err == nil {
-		d = (int64(time.Now().UnixNano()) - prev)
+	if err == nil && prev <= elapsed {
+		d = time.Duration(elapsed - prev)
 	}
 	return
 }

--- a/ndt7/receiver/receiver.go
+++ b/ndt7/receiver/receiver.go
@@ -19,11 +19,12 @@ type receiverKind int
 const (
 	downloadReceiver = receiverKind(iota)
 	uploadReceiver
+	pingReceiver
 )
 
 func loop(
 	ctx context.Context, conn *websocket.Conn, kind receiverKind,
-	dst chan<- model.Measurement,
+	dst chan<- model.Measurement, start time.Time, rttch chan<- time.Duration,
 ) {
 	logging.Logger.Debug("receiver: start")
 	defer logging.Logger.Debug("receiver: stop")
@@ -31,16 +32,16 @@ func loop(
 	conn.SetReadLimit(spec.MaxMessageSize)
 	receiverctx, cancel := context.WithTimeout(ctx, spec.MaxRuntime)
 	defer cancel()
-	err := conn.SetReadDeadline(time.Now().Add(spec.MaxRuntime)) // Liveness!
+	err := conn.SetReadDeadline(start.Add(spec.MaxRuntime)) // Liveness!
 	if err != nil {
 		logging.Logger.WithError(err).Warn("receiver: conn.SetReadDeadline failed")
 		return
 	}
 	conn.SetPongHandler(func(s string) error {
-		rtt, err := ping.ParseTicks(s)
+		rtt, err := ping.ParseTicks(s, start)
 		if err == nil {
-			rtt /= int64(time.Millisecond)
-			logging.Logger.Debugf("receiver: ApplicationLevel RTT: %d ms", rtt)
+			rttch <- rtt // Possibly blocking, but `measurer`
+			logging.Logger.Debugf("receiver: ApplicationLevel RTT: %d ms", rtt.Milliseconds())
 		}
 		return err
 	})
@@ -55,11 +56,11 @@ func loop(
 		}
 		if mtype != websocket.TextMessage {
 			switch kind {
-			case downloadReceiver:
+			case uploadReceiver:
+				continue // No further processing required
+			default: // downloadReceiver and pingReceiver
 				logging.Logger.Warn("receiver: got non-Text message")
 				return // Unexpected message type
-			default:
-				continue // No further processing required
 			}
 		}
 		var measurement model.Measurement
@@ -72,10 +73,11 @@ func loop(
 	}
 }
 
-func start(ctx context.Context, conn *websocket.Conn, kind receiverKind) <-chan model.Measurement {
+func startReceiver(ctx context.Context, conn *websocket.Conn, kind receiverKind, start time.Time) (<-chan model.Measurement, <-chan time.Duration) {
 	dst := make(chan model.Measurement)
-	go loop(ctx, conn, kind, dst)
-	return dst
+	rttch := make(chan time.Duration)
+	go loop(ctx, conn, kind, dst, start, rttch)
+	return dst, rttch
 }
 
 // StartDownloadReceiver starts the receiver in a background goroutine and
@@ -87,13 +89,18 @@ func start(ctx context.Context, conn *websocket.Conn, kind receiverKind) <-chan 
 // Liveness guarantee: the goroutine will always terminate after a
 // MaxRuntime timeout, provided that the consumer will keep reading
 // from the returned channel.
-func StartDownloadReceiver(ctx context.Context, conn *websocket.Conn) <-chan model.Measurement {
-	return start(ctx, conn, downloadReceiver)
+func StartDownloadReceiver(ctx context.Context, conn *websocket.Conn, start time.Time) (<-chan model.Measurement, <-chan time.Duration) {
+	return startReceiver(ctx, conn, downloadReceiver, start)
 }
 
 // StartUploadReceiver is like StartDownloadReceiver except that it
 // tolerates incoming binary messages, which are sent to cause
 // network load, and therefore must not be rejected.
-func StartUploadReceiver(ctx context.Context, conn *websocket.Conn) <-chan model.Measurement {
-	return start(ctx, conn, uploadReceiver)
+func StartUploadReceiver(ctx context.Context, conn *websocket.Conn, start time.Time) (<-chan model.Measurement, <-chan time.Duration)  {
+	return startReceiver(ctx, conn, uploadReceiver, start)
+}
+
+// StartPingReceiver is exactly like StartDownloadReceiver currently.
+func StartPingReceiver(ctx context.Context, conn *websocket.Conn, start time.Time) (<-chan model.Measurement, <-chan time.Duration)  {
+	return startReceiver(ctx, conn, pingReceiver, start)
 }

--- a/ndt7/receiver/receiver.go
+++ b/ndt7/receiver/receiver.go
@@ -47,14 +47,15 @@ func loop(
 	conn.SetPongHandler(func(s string) error {
 		elapsed, rtt, err := ping.ParseTicks(s, start)
 		if err == nil {
-			logging.Logger.Debugf("receiver: ApplicationLevel RTT: %d ms", rtt.Milliseconds())
+			logging.Logger.Debugf("receiver: ApplicationLevel RTT: %d ms", int64(rtt / time.Millisecond))
 			if rtt < minRTT {
 				minRTT = rtt
 			}
+
 			wsinfo := model.WSInfo{
-                ElapsedTime: elapsed.Microseconds(),
-                LastRTT: rtt.Microseconds(),
-                MinRTT: minRTT.Microseconds(),
+				ElapsedTime: int64(elapsed / time.Microsecond),
+				LastRTT: int64(rtt / time.Microsecond),
+				MinRTT: int64(minRTT / time.Microsecond),
 			}
 			pongch <- wsinfo // Liveness: buffered (sender)
 		}

--- a/ndt7/results/file.go
+++ b/ndt7/results/file.go
@@ -66,8 +66,8 @@ func newFile(datadir, what, uuid string) (*File, error) {
 // containing the metadata. The conn argument is used to retrieve the local and
 // the remote endpoints addresses. The "datadir" argument specifies the
 // directory on disk to write the data into and the what argument should
-// indicate whether this is a spec.SubtestDownload or a spec.SubtestUpload
-// ndt7 measurement.
+// indicate whether this is a spec.SubtestDownload, a spec.SubtestUpload
+// or a spec.SubtestPing ndt7 measurement.
 func OpenFor(request *http.Request, conn *websocket.Conn, datadir string, what spec.SubtestKind) (*File, error) {
 	meta := make(metadata, 0)
 	netConn := conn.UnderlyingConn()

--- a/ndt7/spec/spec.go
+++ b/ndt7/spec/spec.go
@@ -9,6 +9,9 @@ const DownloadURLPath = "/ndt/v7/download"
 // UploadURLPath selects the upload subtest.
 const UploadURLPath = "/ndt/v7/upload"
 
+// PingURLPath selects the ping subtest.
+const PingURLPath = "/ndt/v7/ping"
+
 // SecWebSocketProtocol is the WebSocket subprotocol used by ndt7.
 const SecWebSocketProtocol = "net.measurementlab.ndt.v7"
 
@@ -57,4 +60,7 @@ const (
 
 	// SubtestUpload is a upload subtest
 	SubtestUpload = SubtestKind("upload")
+
+	// SubtestPing is a ping subtest
+	SubtestPing = SubtestKind("ping")
 )

--- a/ndt7/upload/upload.go
+++ b/ndt7/upload/upload.go
@@ -23,8 +23,8 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File, start
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	receiverch, rttch := receiver.StartUploadReceiver(wholectx, conn, start)
-	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start, rttch)
-	senderch := sender.Start(conn, measurerch, start)
+	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start)
+	receiverch, pongch := receiver.StartUploadReceiver(wholectx, conn, start)
+	senderch := sender.Start(conn, measurerch, start, pongch)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/upload/upload.go
+++ b/ndt7/upload/upload.go
@@ -3,6 +3,7 @@ package upload
 
 import (
 	"context"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/ndt-server/ndt7/results"
@@ -15,13 +16,15 @@ import (
 // Do implements the upload subtest. The ctx argument is the parent context
 // for the subtest. The conn argument is the open WebSocket connection. The
 // resultfp argument is the file where to save results. Both arguments are
-// owned by the caller of this function.
-func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
+// owned by the caller of this function.  The start argument is the test
+// start time used to calculate ElapsedTime and deadlines.
+func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File, start time.Time) {
 	// Implementation note: use child context so that, if we cannot save the
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
-	receiverch := receiver.StartUploadReceiver(wholectx, conn)
+	receiverch, rttch := receiver.StartUploadReceiver(wholectx, conn, start)
+	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start, rttch)
+	senderch := sender.Start(conn, measurerch, start)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }


### PR DESCRIPTION
That's WIP for #192 

I have a few questions I'm unsure about:
- is it okay to carry `start` around the way it's implemented? It looks a bit messy to me, but I'm quite okay with that.
- does it make sense to send `WSInfo` messages to client in `/upload` and `/download`? I feel like those may be eventually useful, those datapoints feed my curiosity about queuing, but I have no immediate use for the data.
- should `WSInfo` be a separate optional sub-message in the spec or should it extend `AppInfo` with optional fields?
- there is a feedback loop between the goroutines: `sender` (sends ping to) → `[conn]` (eventually delivers pong to) → `receiver` (sends RTT estimate back to client) → `sender`. The current implementation uses buffered channel for RTT estimates to avoid blocking on `pongch <- rtt` while `sender` is blocked on `conn.send(hugeBlob)` feeding the pipe with data. I don't like 14kB being allocated just to handle the worst-case, but I did not come up with a more elegant solution.

WIP:
- [x] ensure that at least one websocket ping is sent ahead of the blob in `download.sender` to get one unbiased sample of L7 RTT for each `/download` for "free"
- [ ] update `spec/ndt7-protocol.md`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/232)
<!-- Reviewable:end -->
