### PR TITLE
Saving websocket RTT samples

### DIFF
--- a/data/result.go
+++ b/data/result.go
@@ -45,4 +45,5 @@ type NDTResult struct {
 	// ndt7
 	Upload   *model.ArchivalData `json:",omitempty"`
 	Download *model.ArchivalData `json:",omitempty"`
+	Ping	 *model.ArchivalData `json:",omitempty"`
 }

--- a/html/ndt7-ping.js
+++ b/html/ndt7-ping.js
@@ -1,0 +1,22 @@
+/* jshint esversion: 6, asi: true, worker: true */
+// WebWorker that runs the ndt7 ping test
+onmessage = function (ev) {
+  'use strict'
+  let url = new URL(ev.data.href)
+  url.protocol = (url.protocol === 'https:') ? 'wss:' : 'ws:'
+  url.pathname = '/ndt/v7/ping'
+  const sock = new WebSocket(url.toString(), 'net.measurementlab.ndt.v7')
+  sock.onclose = function () {
+    postMessage(null)
+  }
+  sock.onopen = function () {
+    sock.onmessage = function (ev) {
+      if (!(ev.data instanceof Blob)) {
+        let m = JSON.parse(ev.data)
+        m.Origin = 'server'
+        m.Test = 'ping'
+        postMessage(m)
+      }
+    }
+  }
+}

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -24,8 +24,10 @@
 </head>
 <body>
   <div>
+    <div id='ping' class='result row'>[Ping]</div>
     <div id='download' class='result row'>[Download]</div>
     <div id='upload' class='result row'>[Upload]</div>
+    <div id='done' class='result row'></div>
   </div>
   <script type='text/javascript'>
     /* jshint esversion: 6, asi: true */
@@ -49,17 +51,34 @@
     }
 
     function runSomething(testName, callback) {
+      let ws = Number.NaN;
+      let tcp = Number.NaN;
       ndt7core.run(location.href, testName, function(ev, val) {
         console.log(ev, val)
         if (ev === 'complete') {
           if (callback !== undefined) {
             callback()
+          } else {
+            withElementDo('done', function (elem) {
+              elem.innerHTML = 'Done.'
+            })
           }
           return
         }
         if (ev === 'measurement' && val.AppInfo !== undefined &&
             val.Origin === 'client') {
           updateView(testName, val.AppInfo)
+        }
+        if (ev === 'measurement' && val.Origin === 'server' && testName === 'ping') {
+          if (val.WSInfo !== undefined) {
+            ws = val.WSInfo.MinRTT / 1e3
+          }
+          if (val.TCPInfo !== undefined) {
+            tcp = val.TCPInfo.MinRTT / 1e3
+          }
+          withElementDo('ping', function (elem) {
+            elem.innerHTML = '⓻ ' + ws.toFixed(1) + ' / ⓸ ' + tcp.toFixed(1) + ' ms'
+          })
         }
       })
     }
@@ -72,7 +91,11 @@
       runSomething('upload', callback)
     }
 
-    runDownload(function() { runUpload(); })
+    function runPing(callback) {
+      runSomething('ping', callback)
+    }
+
+    runPing(function() { runDownload(function() { runUpload(); }); })
   </script>
 </body>
 </html>

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -159,6 +159,7 @@ func main() {
 		}
 		ndt7Mux.Handle(spec.DownloadURLPath, http.HandlerFunc(ndt7Handler.Download))
 		ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))
+		ndt7Mux.Handle(spec.PingURLPath, http.HandlerFunc(ndt7Handler.Ping))
 		ndt7Server := &http.Server{
 			Addr:    *ndt7Addr,
 			Handler: logging.MakeAccessLogHandler(ndt7Mux),

--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -3,6 +3,7 @@ package download
 
 import (
 	"context"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/ndt-server/ndt7/download/sender"
@@ -15,13 +16,15 @@ import (
 // Do implements the download subtest. The ctx argument is the parent
 // context for the subtest. The conn argument is the open WebSocket
 // connection. The resultfp argument is the file where to save results. Both
-// arguments are owned by the caller of this function.
-func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
+// arguments are owned by the caller of this function. The start argument is
+// the test start time used to calculate ElapsedTime and deadlines.
+func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File, start time.Time) {
 	// Implementation note: use child context so that, if we cannot save the
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
-	receiverch := receiver.StartDownloadReceiver(wholectx, conn)
+	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start)
+	receiverch, pongch := receiver.StartDownloadReceiver(wholectx, conn, start, measurerch)
+	senderch := sender.Start(conn, measurerch, start, pongch)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -54,7 +54,7 @@ func measure(measurement *model.Measurement, sockfp *os.File, elapsed time.Durat
 	}
 }
 
-func loop(ctx context.Context, conn *websocket.Conn, UUID string, dst chan<- model.Measurement) {
+func loop(ctx context.Context, conn *websocket.Conn, UUID string, dst chan<- model.Measurement, start time.Time) {
 	logging.Logger.Debug("measurer: start")
 	defer logging.Logger.Debug("measurer: stop")
 	defer close(dst)
@@ -66,7 +66,6 @@ func loop(ctx context.Context, conn *websocket.Conn, UUID string, dst chan<- mod
 		return
 	}
 	defer sockfp.Close()
-	start := time.Now()
 	connectionInfo := &model.ConnectionInfo{
 		Client: conn.RemoteAddr().String(),
 		Server: conn.LocalAddr().String(),
@@ -104,9 +103,9 @@ func loop(ctx context.Context, conn *websocket.Conn, UUID string, dst chan<- mod
 // a timeout of DefaultRuntime seconds, provided that the consumer
 // continues reading from the returned channel.
 func Start(
-	ctx context.Context, conn *websocket.Conn, UUID string,
+	ctx context.Context, conn *websocket.Conn, UUID string, start time.Time,
 ) <-chan model.Measurement {
 	dst := make(chan model.Measurement)
-	go loop(ctx, conn, UUID, dst)
+	go loop(ctx, conn, UUID, dst, start)
 	return dst
 }

--- a/ndt7/model/measurement.go
+++ b/ndt7/model/measurement.go
@@ -8,4 +8,5 @@ type Measurement struct {
 	ConnectionInfo *ConnectionInfo `json:",omitempty" bigquery:"-"`
 	BBRInfo        *BBRInfo        `json:",omitempty"`
 	TCPInfo        *TCPInfo        `json:",omitempty"`
+	WSInfo         *WSInfo	       `json:",omitempty"`
 }

--- a/ndt7/model/wsinfo.go
+++ b/ndt7/model/wsinfo.go
@@ -1,0 +1,10 @@
+package model
+
+// WSInfo contains an application level (websocket) ping measurement data.
+// It may be melded into AppInfo.
+// FIXME: describe this structure is in the ndt7 specification.
+type WSInfo struct {
+    ElapsedTime int64
+    LastRTT     int64 // TCPInfo.RTT is smoothed RTT, LastRTT is just a sample.
+    MinRTT      int64
+}

--- a/ndt7/receiver/receiver.go
+++ b/ndt7/receiver/receiver.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+	"math"
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/ndt-server/logging"
@@ -19,28 +20,44 @@ type receiverKind int
 const (
 	downloadReceiver = receiverKind(iota)
 	uploadReceiver
+	pingReceiver
+)
+
+const (
+	MaxDuration = math.MaxInt64 * time.Nanosecond
 )
 
 func loop(
 	ctx context.Context, conn *websocket.Conn, kind receiverKind,
-	dst chan<- model.Measurement,
+	dst chan<- model.Measurement, start time.Time, pongch chan<- model.WSInfo,
 ) {
 	logging.Logger.Debug("receiver: start")
 	defer logging.Logger.Debug("receiver: stop")
 	defer close(dst)
+	defer close(pongch)
 	conn.SetReadLimit(spec.MaxMessageSize)
 	receiverctx, cancel := context.WithTimeout(ctx, spec.MaxRuntime)
 	defer cancel()
-	err := conn.SetReadDeadline(time.Now().Add(spec.MaxRuntime)) // Liveness!
+	err := conn.SetReadDeadline(start.Add(spec.MaxRuntime)) // Liveness!
 	if err != nil {
 		logging.Logger.WithError(err).Warn("receiver: conn.SetReadDeadline failed")
 		return
 	}
+	minRTT := MaxDuration
 	conn.SetPongHandler(func(s string) error {
-		rtt, err := ping.ParseTicks(s)
+		elapsed, rtt, err := ping.ParseTicks(s, start)
 		if err == nil {
-			rtt /= int64(time.Millisecond)
-			logging.Logger.Debugf("receiver: ApplicationLevel RTT: %d ms", rtt)
+			logging.Logger.Debugf("receiver: ApplicationLevel RTT: %d ms", int64(rtt / time.Millisecond))
+			if rtt < minRTT {
+				minRTT = rtt
+			}
+
+			wsinfo := model.WSInfo{
+				ElapsedTime: int64(elapsed / time.Microsecond),
+				LastRTT: int64(rtt / time.Microsecond),
+				MinRTT: int64(minRTT / time.Microsecond),
+			}
+			pongch <- wsinfo // Liveness: buffered (sender)
 		}
 		return err
 	})
@@ -55,11 +72,11 @@ func loop(
 		}
 		if mtype != websocket.TextMessage {
 			switch kind {
-			case downloadReceiver:
+			case uploadReceiver:
+				continue // No further processing required
+			default: // downloadReceiver and pingReceiver
 				logging.Logger.Warn("receiver: got non-Text message")
 				return // Unexpected message type
-			default:
-				continue // No further processing required
 			}
 		}
 		var measurement model.Measurement
@@ -72,10 +89,15 @@ func loop(
 	}
 }
 
-func start(ctx context.Context, conn *websocket.Conn, kind receiverKind) <-chan model.Measurement {
+func startReceiver(ctx context.Context, conn *websocket.Conn, kind receiverKind, start time.Time) (<-chan model.Measurement, <-chan model.WSInfo) {
+	// |dst| is going to the log file
 	dst := make(chan model.Measurement)
-	go loop(ctx, conn, kind, dst)
-	return dst
+	// |pongch| goes to the client, it's buffered to avoid blocking on `download.sender.loop`
+	// while `conn.WritePreparedMessage()` is active.
+	// TODO(darkk): is it possible to reduce buffer size or to avoiding blocking in some other way? May avoiding L7 pings at /download altogether be the way?
+	pongch := make(chan model.WSInfo, 1 + spec.MaxRuntime / spec.MinPoissonSamplingInterval)
+	go loop(ctx, conn, kind, dst, start, pongch)
+	return dst, pongch
 }
 
 // StartDownloadReceiver starts the receiver in a background goroutine and
@@ -87,13 +109,18 @@ func start(ctx context.Context, conn *websocket.Conn, kind receiverKind) <-chan 
 // Liveness guarantee: the goroutine will always terminate after a
 // MaxRuntime timeout, provided that the consumer will keep reading
 // from the returned channel.
-func StartDownloadReceiver(ctx context.Context, conn *websocket.Conn) <-chan model.Measurement {
-	return start(ctx, conn, downloadReceiver)
+func StartDownloadReceiver(ctx context.Context, conn *websocket.Conn, start time.Time, msmch <-chan model.Measurement) (<-chan model.Measurement, <-chan model.WSInfo) {
+	return startReceiver(ctx, conn, downloadReceiver, start)
 }
 
 // StartUploadReceiver is like StartDownloadReceiver except that it
 // tolerates incoming binary messages, which are sent to cause
 // network load, and therefore must not be rejected.
-func StartUploadReceiver(ctx context.Context, conn *websocket.Conn) <-chan model.Measurement {
-	return start(ctx, conn, uploadReceiver)
+func StartUploadReceiver(ctx context.Context, conn *websocket.Conn, start time.Time) (<-chan model.Measurement, <-chan model.WSInfo) {
+	return startReceiver(ctx, conn, uploadReceiver, start)
+}
+
+// StartPingReceiver is exactly like StartDownloadReceiver currently.
+func StartPingReceiver(ctx context.Context, conn *websocket.Conn, start time.Time) (<-chan model.Measurement, <-chan model.WSInfo) {
+	return startReceiver(ctx, conn, pingReceiver, start)
 }

--- a/ndt7/results/file.go
+++ b/ndt7/results/file.go
@@ -66,8 +66,8 @@ func newFile(datadir, what, uuid string) (*File, error) {
 // containing the metadata. The conn argument is used to retrieve the local and
 // the remote endpoints addresses. The "datadir" argument specifies the
 // directory on disk to write the data into and the what argument should
-// indicate whether this is a spec.SubtestDownload or a spec.SubtestUpload
-// ndt7 measurement.
+// indicate whether this is a spec.SubtestDownload, a spec.SubtestUpload
+// or a spec.SubtestPing ndt7 measurement.
 func OpenFor(request *http.Request, conn *websocket.Conn, datadir string, what spec.SubtestKind) (*File, error) {
 	meta := make(metadata, 0)
 	netConn := conn.UnderlyingConn()

--- a/ndt7/spec/spec.go
+++ b/ndt7/spec/spec.go
@@ -9,6 +9,9 @@ const DownloadURLPath = "/ndt/v7/download"
 // UploadURLPath selects the upload subtest.
 const UploadURLPath = "/ndt/v7/upload"
 
+// PingURLPath selects the ping subtest.
+const PingURLPath = "/ndt/v7/ping"
+
 // SecWebSocketProtocol is the WebSocket subprotocol used by ndt7.
 const SecWebSocketProtocol = "net.measurementlab.ndt.v7"
 
@@ -57,4 +60,7 @@ const (
 
 	// SubtestUpload is a upload subtest
 	SubtestUpload = SubtestKind("upload")
+
+	// SubtestPing is a ping subtest
+	SubtestPing = SubtestKind("ping")
 )

--- a/ndt7/upload/upload.go
+++ b/ndt7/upload/upload.go
@@ -3,6 +3,7 @@ package upload
 
 import (
 	"context"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/ndt-server/ndt7/results"
@@ -15,13 +16,15 @@ import (
 // Do implements the upload subtest. The ctx argument is the parent context
 // for the subtest. The conn argument is the open WebSocket connection. The
 // resultfp argument is the file where to save results. Both arguments are
-// owned by the caller of this function.
-func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
+// owned by the caller of this function.  The start argument is the test
+// start time used to calculate ElapsedTime and deadlines.
+func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File, start time.Time) {
 	// Implementation note: use child context so that, if we cannot save the
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
-	receiverch := receiver.StartUploadReceiver(wholectx, conn)
+	measurerch := measurer.Start(wholectx, conn, resultfp.Data.UUID, start)
+	receiverch, pongch := receiver.StartUploadReceiver(wholectx, conn, start)
+	senderch := sender.Start(conn, measurerch, start, pongch)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -7,18 +7,19 @@ protocol](https://github.com/ndt-project/ndt). Ndt7 is based on
 WebSocket and TLS, and takes advantage of TCP BBR, where this
 flavour of TCP is available.
 
-This is version v0.8.3 of the ndt7 specification.
+This is version v0.9.0 of the ndt7 specification.
 
 ## Design choices
 
 (This section is non-normative.)
 
 Ndt7 measures the application-level download and upload performance
-using WebSockets over TLS. Each test type is independent, and
-there are two types of test: the download and the upload tests. Ndt7
-always uses a single TCP connection. Whenever possible, ndt7 uses a recent
-version of TCP BBR. Writing an ndt7 client is designed to be as simple
-as possible. [A complete Go language ndt7 client](
+using WebSockets over TLS. Each test type is independent, and there are
+three types of test: the download, the upload tests, and the latency
+test. Ndt7 always uses a single new TCP connection for each type of
+test. Whenever possible, ndt7 uses a recent version of TCP BBR. Writing
+an ndt7 client is designed to be as simple as possible. [A complete Go
+language ndt7 client](
 https://github.com/bassosimone/ndt7-client-go-minimal) has been implemented
 in just 151 lines. We used 26 lines for the download, 33 for the upload, and
 17 for establishing a connections. No code from the NDT server has been
@@ -68,12 +69,14 @@ servers should behave during the download and the upload tests.
 The client connects to the server using HTTPS and requests to upgrade the
 connection to WebSockets. The same connection will be used to exchange
 control and measurement messages. The upgrade request URL will indicate
-the type of test that the client wants to perform. Two tests and
-hence two URLs are defined:
+the type of test that the client wants to perform. Three tests and
+hence three URLs are defined:
 
 - `/ndt/v7/download`, which selects the download test;
 
-- `/ndt/v7/upload`, which selects the upload test.
+- `/ndt/v7/upload`, which selects the upload test;
+
+- `/ndt/v7/ping`, which selects the ping test.
 
 The upgrade message MUST also contain the WebSocket subprotocol that
 identifies ndt7, which is `net.measurementlab.ndt.v7`. The URL in the
@@ -199,14 +202,14 @@ provide information useful to diagnose performance issues.
 While in theory we could specify all `TCP_INFO` and `BBR_INFO` variables,
 different kernel versions provide different subsets of these measurements
 and we do not want to be needlessly restrictive regarding the underlying
-kernel for the server. Instead, 
+kernel for the server. Instead,
 our guiding principle is to describe only the variables that in our
 experience are useful to understand performance issues. More variables
 could be added in the future. No variables should be removed, but, if
 some are removed, we should document them as being removed rather than
 removing them from this specification.
 
-Since version v0.8.0 of this specification, the measurement message
+Since version v0.9.0 of this specification, the measurement message
 has the following structure:
 
 ```json
@@ -222,6 +225,11 @@ has the following structure:
   },
   "Origin": "server",
   "Test": "download",
+  "WSInfo": {
+    "ElapsedTime": 1234,
+    "LastRTT": 134,
+    "MinRTT": 1234
+  },
   "TCPInfo": {
     "BusyTime": 1234,
     "BytesAcked": 1234,
@@ -280,6 +288,18 @@ Where:
 - `Test` is an _optional_ `string` that indicates the name of the
   current test. This field SHOULD only be used when the current test
   should otherwise not be obvious.
+
+- `WSInfo` is an _optional_ `object` only included in the measurement
+  when a reasonable websocket-level measurement is available:
+
+    - `ElapsedTime` (a `int64`) is the time elapsed since the beginning of
+      this test, measured in microseconds.
+
+    - `LastRTT` (an _optional_ `int64`), the last observed RTT for the websocket
+      ping-pong exchange, measured in microseconds.
+
+    - `MinRTT` (an _optional_ `int64`), the minimum observed RTT for the websocket
+      ping-pong exchange, measured in microseconds.
 
 - `TCPInfo` is an _optional_ `object` only included in the measurement
   when it is possible to access `TCP_INFO` stats. It contains:
@@ -387,9 +407,11 @@ When the server sends measurement messages, the download becomes:
 ```
 > GET /ndt/v7/download Upgrade: websocket
 < 101 Switching Protocols
+< PingMessage
 < BinaryMessage
 < BinaryMessage
 < TextMessage    clientElapsedTime=0.30 s
+> PongMessage
 < BinaryMessage
 < BinaryMessage
 < TextMessage    clientElapsedTime=0.55 s
@@ -645,7 +667,9 @@ of the round-trip time. The buildup of a large queue is unexpected when using
 BBR. It generally indicates the presence of a bottleneck with a large buffer
 that's filling as the test proceeds. The `MinRTT` can also be useful to verify
 we're using a reasonably nearby-server. Also, an unreasonably small RTT when
-the link is 2G or 3G could indicate a performance enhancing proxy.
+the link is 2G or 3G could indicate a performance enhancing proxy, one can
+compare `TCPInfo.MinRTT` against `WSInfo.MinRTT` to get additional evidence
+supporing this case.
 
 The times (`BusyTime`, `RWndLimited`, and `SndBufLimited`) are useful to
 understand where the bottleneck could be. In general we would like to see
@@ -679,3 +703,18 @@ packet is uniformly distributed, which isn't likely the case. Yet, it
 may be an useful first order information to characterise a network
 as possibly very lossy. Some packet loss is normal and healthy, but
 too much packet loss is the sign of a network path with systemic problems.
+
+### Measuring latency
+
+The presence of TCP-level proxies leads to L7 means being needed to
+measure end-to-end latency in addition to end-to-end bandwidth. Such
+proxies may include ISP-level performance-enhancing proxies, OpenSSH,
+Tor anonymity network and many others.
+
+`WSInfo.LastRTT` samples may be affected by the payload during download
+and upload tests, as the queue of BinaryMessage may delay either ping
+or pong frame. Ping test does not send BinaryMessage payload, so WSInfo
+RTT measurements should be reasonably accurate (unless it's practical
+for the client to delay pong frames). The very first `WSInfo` sample
+collected during the download test also has a chance to be accurate as
+the ping frame SHOULD precede any BinaryMessages in the case.


### PR DESCRIPTION
That's WIP for #192, reopened per [the comment](https://github.com/m-lab/ndt-server/pull/232#issuecomment-576624672) in #232.

I have a question I'm unsure about:

- is it okay to carry start around the way it's implemented? It looks a bit messy to me, but I'm quite okay with that.

WIP is:
- [ ] send only the first `WSInfo` during _download_ test. It breaks the feedback loop and makes queue management easier. Biased RTT estimates are not so interesting in the real time.