### PR TITLE
ndt7: start refactoring to reduce the number of channels

### DIFF
--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -21,7 +21,8 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
+	measurer := measurer.New(conn, resultfp.Data.UUID)
+	senderch := sender.Start(conn, measurer.Start(ctx))
 	receiverch := receiver.StartDownloadReceiver(wholectx, conn)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -18,8 +18,22 @@ import (
 	"github.com/m-lab/ndt-server/tcpinfox"
 )
 
-func getSocketAndPossiblyEnableBBR(conn *websocket.Conn) (*os.File, error) {
-	fp := fdcache.GetAndForgetFile(conn.UnderlyingConn())
+// Measurer performs measurements
+type Measurer struct {
+	conn *websocket.Conn
+	uuid string
+}
+
+// New creates a new measurer instance
+func New(conn *websocket.Conn, UUID string) *Measurer {
+	return &Measurer{
+		conn: conn,
+		uuid: UUID,
+	}
+}
+
+func (m *Measurer) getSocketAndPossiblyEnableBBR() (*os.File, error) {
+	fp := fdcache.GetAndForgetFile(m.conn.UnderlyingConn())
 	// Implementation note: in theory fp SHOULD always be non-nil because
 	// now we always register the fp bound to a net.TCPConn. However, in
 	// some weird cases it MAY happen that the cache pruning mechanism will
@@ -54,13 +68,13 @@ func measure(measurement *model.Measurement, sockfp *os.File, elapsed time.Durat
 	}
 }
 
-func loop(ctx context.Context, conn *websocket.Conn, UUID string, dst chan<- model.Measurement) {
+func (m *Measure) loop(ctx context.Context, dst chan<- model.Measurement) {
 	logging.Logger.Debug("measurer: start")
 	defer logging.Logger.Debug("measurer: stop")
 	defer close(dst)
 	measurerctx, cancel := context.WithTimeout(ctx, spec.DefaultRuntime)
 	defer cancel()
-	sockfp, err := getSocketAndPossiblyEnableBBR(conn)
+	sockfp, err := m.getSocketAndPossiblyEnableBBR()
 	if err != nil {
 		logging.Logger.WithError(err).Warn("getSocketAndPossiblyEnableBBR failed")
 		return
@@ -68,9 +82,9 @@ func loop(ctx context.Context, conn *websocket.Conn, UUID string, dst chan<- mod
 	defer sockfp.Close()
 	start := time.Now()
 	connectionInfo := &model.ConnectionInfo{
-		Client: conn.RemoteAddr().String(),
-		Server: conn.LocalAddr().String(),
-		UUID:   UUID,
+		Client: m.conn.RemoteAddr().String(),
+		Server: m.conn.LocalAddr().String(),
+		UUID:   m.uuid,
 	}
 	// Implementation note: the ticker will close its output channel
 	// after the controlling context is expired.
@@ -103,10 +117,8 @@ func loop(ctx context.Context, conn *websocket.Conn, UUID string, dst chan<- mod
 // Liveness guarantee: the measurer will always terminate after
 // a timeout of DefaultRuntime seconds, provided that the consumer
 // continues reading from the returned channel.
-func Start(
-	ctx context.Context, conn *websocket.Conn, UUID string,
-) <-chan model.Measurement {
+func (m *Measurer) Start(ctx context.Context) <-chan model.Measurement {
 	dst := make(chan model.Measurement)
-	go loop(ctx, conn, UUID, dst)
+	go m.loop(ctx, dst)
 	return dst
 }

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -68,7 +68,7 @@ func measure(measurement *model.Measurement, sockfp *os.File, elapsed time.Durat
 	}
 }
 
-func (m *Measure) loop(ctx context.Context, dst chan<- model.Measurement) {
+func (m *Measurer) loop(ctx context.Context, dst chan<- model.Measurement) {
 	logging.Logger.Debug("measurer: start")
 	defer logging.Logger.Debug("measurer: stop")
 	defer close(dst)

--- a/ndt7/upload/upload.go
+++ b/ndt7/upload/upload.go
@@ -5,9 +5,9 @@ import (
 	"context"
 
 	"github.com/gorilla/websocket"
-	"github.com/m-lab/ndt-server/ndt7/results"
 	"github.com/m-lab/ndt-server/ndt7/measurer"
 	"github.com/m-lab/ndt-server/ndt7/receiver"
+	"github.com/m-lab/ndt-server/ndt7/results"
 	"github.com/m-lab/ndt-server/ndt7/saver"
 	"github.com/m-lab/ndt-server/ndt7/upload/sender"
 )
@@ -21,7 +21,8 @@ func Do(ctx context.Context, conn *websocket.Conn, resultfp *results.File) {
 	// results in the loop below, we terminate the goroutines early
 	wholectx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	senderch := sender.Start(conn, measurer.Start(wholectx, conn, resultfp.Data.UUID))
+	measurer := measurer.New(conn, resultfp.Data.UUID)
+	senderch := sender.Start(conn, measurer.Start(ctx))
 	receiverch := receiver.StartUploadReceiver(wholectx, conn)
 	saver.SaveAll(resultfp, senderch, receiverch)
 }


### PR DESCRIPTION
As documented in #238, we would like to reduce the pipeline
structure and the dependency on channels. We have a reasonably
clear idea of what we want to do.

Let us do this piecemeal.

In this first diff, I'm changing the measurer to be a
struct rather than just a func. By doing that, I'm
creating the opportunity for storing the measurements
collected by the measurer into the measurer itself rather
than publishing them downstream to a channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/248)
<!-- Reviewable:end -->
