### PR TITLE
Remove connection to ETL pipeline.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,10 +6,6 @@ set -ex
 # Test the NDT binary
 PATH=${PATH}:${GOPATH}/bin
 
-# Check that we haven't blatently broken etl dependencies.
-go get -t github.com/m-lab/etl/...
-go vet github.com/m-lab/etl/...
-
 # If we aren't running on Travis, then there's no need to produce a coverage
 # file and submit it to coveralls.io
 if [[ -z ${TRAVIS_PULL_REQUEST} ]]; then


### PR DESCRIPTION
Now that ETL is using modules, this bidirectional "code health" check has strictly negative value for NDT-server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/253)
<!-- Reviewable:end -->
