### PR TITLE
Add access control to ndt7:80 and ignore TxController errors

### DIFF
--- a/access/tx.go
+++ b/access/tx.go
@@ -2,6 +2,7 @@ package access
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -25,10 +26,11 @@ var (
 		},
 		[]string{"request"},
 	)
+	ErrNoDevice = errors.New("no device found")
 )
 
 func init() {
-	flag.StringVar(&device, "txcontroller.device", "eth0", "Calculate bytes transmitted from this device.")
+	flag.StringVar(&device, "txcontroller.device", "", "Calculate bytes transmitted from this device.")
 }
 
 // TxController calculates the bytes transmitted every period from the named device.
@@ -43,6 +45,9 @@ type TxController struct {
 // NewTxController creates a new instance initialized to run every second.
 // Caller should run Watch in a goroutine to regularly update the current rate.
 func NewTxController(rate uint64) (*TxController, error) {
+	if device == "" {
+		return nil, ErrNoDevice
+	}
 	pfs, err := procfs.NewFS(procPath)
 	if err != nil {
 		return nil, err

--- a/access/tx_test.go
+++ b/access/tx_test.go
@@ -16,7 +16,7 @@ import (
 func TestTxController_Limit(t *testing.T) {
 	tests := []struct {
 		name     string
-		limit uint64
+		limit    uint64
 		current  uint64
 		procPath string
 		visited  bool
@@ -29,7 +29,7 @@ func TestTxController_Limit(t *testing.T) {
 		},
 		{
 			name:     "reject",
-			limit :     1,
+			limit:    1,
 			current:  2,
 			procPath: "testdata/proc-success",
 			visited:  false,
@@ -38,6 +38,7 @@ func TestTxController_Limit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			procPath = tt.procPath
+			device = "eth0"
 			tx, err := NewTxController(tt.limit)
 			if !tt.wantErr && (err != nil) {
 				t.Errorf("NewTxController() got %v, want %t", err, tt.wantErr)
@@ -64,7 +65,7 @@ func TestTxController_Limit(t *testing.T) {
 func TestNewTxController(t *testing.T) {
 	tests := []struct {
 		name     string
-		limit uint64
+		limit    uint64
 		want     *TxController
 		procPath string
 		wantErr  bool
@@ -102,29 +103,29 @@ func TestNewTxController(t *testing.T) {
 
 func TestTxController_Watch(t *testing.T) {
 	tests := []struct {
-		name     string
-		limit uint64
-		want     *TxController
-		procPath string
-		badProc string
-		wantWatchErr  bool
+		name         string
+		limit        uint64
+		want         *TxController
+		procPath     string
+		badProc      string
+		wantWatchErr bool
 	}{
 		{
 			name:     "success-zero-rate",
 			procPath: "testdata/proc-success",
-			limit: 0,
+			limit:    0,
 		},
 		{
-			name:     "success-rate",
-			procPath: "testdata/proc-success",
-			limit: 1,
+			name:         "success-rate",
+			procPath:     "testdata/proc-success",
+			limit:        1,
 			wantWatchErr: true,
 		},
 		{
-			name:     "success-error-reading-proc",
-			procPath: "testdata/proc-success",
-			limit: 1,
-			badProc: "testdata/proc-nodevfile",
+			name:         "success-error-reading-proc",
+			procPath:     "testdata/proc-success",
+			limit:        1,
+			badProc:      "testdata/proc-nodevfile",
 			wantWatchErr: true,
 		},
 	}

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -123,6 +123,8 @@ func main() {
 		// Only watch interface and run tx.Limit on success.
 		go tx.Watch(ctx)
 		ac.Append(tx.Limit)
+	} else {
+		log.Println("WARNING: access.TxController disabled:", err)
 	}
 
 	// The ndt5 protocol serving non-HTTP-based tests - forwards to Ws-based

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -10,11 +10,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/m-lab/go/prometheusx"
-
 	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
-
 	"github.com/m-lab/ndt-server/access"
 	"github.com/m-lab/ndt-server/logging"
 	ndt5handler "github.com/m-lab/ndt-server/ndt5/handler"
@@ -24,21 +22,22 @@ import (
 	"github.com/m-lab/ndt-server/ndt7/spec"
 	"github.com/m-lab/ndt-server/platformx"
 
+	"github.com/justinas/alice"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
 	// Flags that can be passed in on the command line
-	ndt7Addr    = flag.String("ndt7_addr", ":443", "The address and port to use for the ndt7 test")
+	ndt7Addr          = flag.String("ndt7_addr", ":443", "The address and port to use for the ndt7 test")
 	ndt7AddrCleartext = flag.String("ndt7_addr_cleartext", ":80", "The address and port to use for the ndt7 cleartext test")
-	ndt5Addr    = flag.String("ndt5_addr", ":3001", "The address and port to use for the unencrypted ndt5 test")
-	ndt5WsAddr  = flag.String("ndt5_ws_addr", "127.0.0.1:3002", "The address and port to use for the ndt5 WS test")
-	ndt5WssAddr = flag.String("ndt5_wss_addr", ":3010", "The address and port to use for the ndt5 WSS test")
-	certFile    = flag.String("cert", "", "The file with server certificates in PEM format.")
-	keyFile     = flag.String("key", "", "The file with server key in PEM format.")
-	dataDir     = flag.String("datadir", "/var/spool/ndt", "The directory in which to write data files")
-	maxRate     = flag.Uint64("max-rate", 0, "The max rate beyond which, the TxController will reject new clients")
+	ndt5Addr          = flag.String("ndt5_addr", ":3001", "The address and port to use for the unencrypted ndt5 test")
+	ndt5WsAddr        = flag.String("ndt5_ws_addr", "127.0.0.1:3002", "The address and port to use for the ndt5 WS test")
+	ndt5WssAddr       = flag.String("ndt5_wss_addr", ":3010", "The address and port to use for the ndt5 WSS test")
+	certFile          = flag.String("cert", "", "The file with server certificates in PEM format.")
+	keyFile           = flag.String("key", "", "The file with server key in PEM format.")
+	dataDir           = flag.String("datadir", "/var/spool/ndt", "The directory in which to write data files")
+	maxRate           = flag.Uint64("max-rate", 0, "The max rate beyond which, the TxController will reject new clients")
 
 	// A metric to use to signal that the server is in lame duck mode.
 	lameDuck = promauto.NewGauge(prometheus.GaugeOpts{
@@ -117,9 +116,14 @@ func main() {
 
 	platformx.WarnIfNotFullySupported()
 
+	// Setup sequence of access control http.Handlers.
+	ac := alice.New()
 	tx, err := access.NewTxController(*maxRate)
-	rtx.Must(err, "Failed to allocate new TxController")
-	go tx.Watch(ctx)
+	if err == nil {
+		// Only watch interface and run tx.Limit on success.
+		go tx.Watch(ctx)
+		ac.Append(tx.Limit)
+	}
 
 	// The ndt5 protocol serving non-HTTP-based tests - forwards to Ws-based
 	// server if the first three bytes are "GET".
@@ -136,7 +140,7 @@ func main() {
 	ndt5WsMux.Handle("/ndt_protocol", ndt5handler.NewWS(*dataDir+"/ndt5"))
 	ndt5WsServer := &http.Server{
 		Addr:    *ndt5WsAddr,
-		Handler: tx.Limit(logging.MakeAccessLogHandler(ndt5WsMux)),
+		Handler: ac.Then(logging.MakeAccessLogHandler(ndt5WsMux)),
 	}
 	log.Println("About to listen for unencrypted ndt5 NDT tests on " + *ndt5WsAddr)
 	rtx.Must(listener.ListenAndServeAsync(ndt5WsServer), "Could not start unencrypted ndt5 NDT server")
@@ -153,7 +157,7 @@ func main() {
 	ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))
 	ndt7ServerCleartext := &http.Server{
 		Addr:    *ndt7AddrCleartext,
-		Handler: logging.MakeAccessLogHandler(ndt7Mux),
+		Handler: ac.Then(logging.MakeAccessLogHandler(ndt7Mux)),
 	}
 	log.Println("About to listen for ndt7 cleartext tests on " + *ndt7AddrCleartext)
 	rtx.Must(listener.ListenAndServeAsync(ndt7ServerCleartext), "Could not start ndt7 cleartext server")
@@ -168,7 +172,7 @@ func main() {
 		ndt5WssMux.Handle("/ndt_protocol", ndt5handler.NewWSS(*dataDir+"/ndt5", *certFile, *keyFile))
 		ndt5WssServer := &http.Server{
 			Addr:    *ndt5WssAddr,
-			Handler: tx.Limit(logging.MakeAccessLogHandler(ndt5WssMux)),
+			Handler: ac.Then(logging.MakeAccessLogHandler(ndt5WssMux)),
 		}
 		log.Println("About to listen for ndt5 WsS tests on " + *ndt5WssAddr)
 		rtx.Must(listener.ListenAndServeTLSAsync(ndt5WssServer, *certFile, *keyFile), "Could not start ndt5 WsS server")
@@ -177,7 +181,7 @@ func main() {
 		// The ndt7 listener serving up WSS based tests
 		ndt7Server := &http.Server{
 			Addr:    *ndt7Addr,
-			Handler: tx.Limit(logging.MakeAccessLogHandler(ndt7Mux)),
+			Handler: ac.Then(logging.MakeAccessLogHandler(ndt7Mux)),
 		}
 		log.Println("About to listen for ndt7 tests on " + *ndt7Addr)
 		rtx.Must(listener.ListenAndServeTLSAsync(ndt7Server, *certFile, *keyFile), "Could not start ndt7 server")


### PR DESCRIPTION
This change adds the access controller to ndt7 clear text handler and generalizes the access controller setup to allow chaining multiple controllers in the future. This change also allows TxController to be disabled with a warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/259)
<!-- Reviewable:end -->
