### PR TITLE
Apply TxController to ndt5 "plain" socket Accept calls

### DIFF
--- a/access/tx.go
+++ b/access/tx.go
@@ -18,9 +18,9 @@ import (
 )
 
 var (
-	procPath       = "/proc"
-	device         string
-	accessRequests = promauto.NewCounterVec(
+	procPath         = "/proc"
+	device           string
+	txAccessRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ndt_access_txcontroller_requests_total",
 			Help: "Total number of requests handled by the access txcontroller.",
@@ -89,10 +89,10 @@ func (tx *TxController) Current() uint64 {
 func (tx *TxController) isLimited(proto string) bool {
 	cur := atomic.LoadUint64(&tx.current)
 	if tx.limit > 0 && cur > tx.limit {
-		accessRequests.WithLabelValues("rejected", proto).Inc()
+		txAccessRequests.WithLabelValues("rejected", proto).Inc()
 		return true
 	}
-	accessRequests.WithLabelValues("accepted", proto).Inc()
+	txAccessRequests.WithLabelValues("accepted", proto).Inc()
 	return false
 }
 

--- a/access/tx.go
+++ b/access/tx.go
@@ -155,7 +155,7 @@ func (tx *TxController) Watch(ctx context.Context) error {
 		}
 
 		// Under heavy load, tickers may fire slow (and then early). Only update
-		// metrics when interval is long enough, i.e. more than half 'alpha'.
+		// values when interval is long enough, i.e. more than half 'alpha'.
 		if tickNow.Sub(tickPrev).Seconds() > alpha/2 {
 			// Calculate the new rate in bits-per-second, using the actual interval.
 			rateNow := float64(8*(cur.TxBytes-prevTxBytes)) / tickNow.Sub(tickPrev).Seconds()

--- a/access/tx.go
+++ b/access/tx.go
@@ -155,8 +155,8 @@ func (tx *TxController) Watch(ctx context.Context) error {
 		}
 
 		// Under heavy load, tickers may fire slow (and then early). Only update
-		// values when interval is long enough, i.e. more than half 'alpha'.
-		if tickNow.Sub(tickPrev).Seconds() > alpha/2 {
+		// values when interval is long enough, i.e. more than half the tx.period.
+		if tickNow.Sub(tickPrev).Seconds() > tx.period.Seconds()/2 {
 			// Calculate the new rate in bits-per-second, using the actual interval.
 			rateNow := float64(8*(cur.TxBytes-prevTxBytes)) / tickNow.Sub(tickPrev).Seconds()
 			// A few seconds for decreases and rapid response for increases.

--- a/access/tx.go
+++ b/access/tx.go
@@ -65,13 +65,17 @@ func NewTxController(rate uint64) (*TxController, error) {
 		pfs:    pfs,
 		period: 100 * time.Millisecond,
 	}
-	return tx, err
+	return tx, nil
 }
 
 // Accept wraps the call to listener's Accept. If the TxController is
 // limited, then Accept immediately closes the connection and returns an error.
 func (tx *TxController) Accept(l net.Listener) (net.Conn, error) {
 	conn, err := l.Accept()
+	if tx == nil {
+		// Simple pass-through.
+		return conn, err
+	}
 	if err == nil && tx.isLimited("raw") {
 		defer conn.Close()
 		return nil, fmt.Errorf("TxController rejected connection %s", conn.RemoteAddr())

--- a/access/tx_test.go
+++ b/access/tx_test.go
@@ -2,6 +2,7 @@ package access
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -225,6 +226,12 @@ func TestTxController_Accept(t *testing.T) {
 			name: "success-accept-with-nil-tx",
 			l:    &fakeListener{conn: fakeConn{}},
 			tx:   nil, // Accept should work even with a nil tx.
+		},
+		{
+			name:    "error-accept-returns-error",
+			l:       &fakeListener{err: errors.New("this is a fake accept error")},
+			tx:      &TxController{},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/access/tx_test.go
+++ b/access/tx_test.go
@@ -198,34 +198,38 @@ func TestTxController_Accept(t *testing.T) {
 	tests := []struct {
 		name       string
 		l          *fakeListener
-		current    uint64
-		limit      uint64
+		tx         *TxController
 		wantClosed int
 		wantErr    bool
 	}{
 		{
-			name:       "success-accepted",
-			l:          &fakeListener{},
-			current:    0,
-			limit:      1,
+			name: "success-accepted",
+			l:    &fakeListener{},
+			tx: &TxController{
+				current: 0,
+				limit:   1,
+			},
 			wantClosed: 0,
 		},
 		{
-			name:       "success-rejected",
-			l:          &fakeListener{conn: fakeConn{}},
-			current:    2,
-			limit:      1,
+			name: "success-rejected",
+			l:    &fakeListener{conn: fakeConn{}},
+			tx: &TxController{
+				current: 2,
+				limit:   1,
+			},
 			wantClosed: 1,
 			wantErr:    true,
+		},
+		{
+			name: "success-accept-with-nil-tx",
+			l:    &fakeListener{conn: fakeConn{}},
+			tx:   nil, // Accept should work even with a nil tx.
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tx := &TxController{
-				current: tt.current,
-				limit:   tt.limit,
-			}
-			conn, err := tx.Accept(tt.l)
+			conn, err := tt.tx.Accept(tt.l)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TxController.Accept() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Two changes:

1. Check device TX usage every 100ms instead of 1sec, with a slow decay. 
2. Apply TxController to ndt5 plain socket Accept calls.

The combination of these changes will apply the tx limit to all control connections and add some hysteresis to interface usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/268)
<!-- Reviewable:end -->
