### PR TITLE
Add access.TokenController for monitoring-aware token-based access control

### DIFF
--- a/access/control.go
+++ b/access/control.go
@@ -1,0 +1,33 @@
+package access
+
+import (
+	"context"
+	"net/http"
+)
+
+// Controller is the interface that all access control types should implement.
+type Controller interface {
+	Limit(next http.Handler) http.Handler
+}
+
+type monitoringContextIDType struct{}
+
+var monitoringContextIDKey = monitoringContextIDType{}
+
+// SetMonitoring returns a derived context with the given value.
+func SetMonitoring(ctx context.Context, value bool) context.Context {
+	// Add a context value to pass advisory information to the next handler.
+	return context.WithValue(ctx, monitoringContextIDKey, value)
+}
+
+// GetMonitoring attempts to extract the monitoring value from the given context.
+func GetMonitoring(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	value := ctx.Value(monitoringContextIDKey)
+	if value == nil {
+		return false
+	}
+	return value.(bool)
+}

--- a/access/control_test.go
+++ b/access/control_test.go
@@ -1,0 +1,27 @@
+package access
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetMonitoring(t *testing.T) {
+	// Set monitoring value true.
+	ctx := context.Background()
+	ctx = SetMonitoring(ctx, true)
+	if m := GetMonitoring(ctx); !m {
+		t.Errorf("Set/GetMonitoring() wrong; got %t, want %t", m, true)
+	}
+
+	// Set monitoring value false.
+	ctx = context.Background()
+	ctx = SetMonitoring(ctx, false)
+	if m := GetMonitoring(ctx); m {
+		t.Errorf("Set/GetMonitoring() wrong; got %t, want %t", m, false)
+	}
+
+	// Verify that a nil context WAI.
+	if m := GetMonitoring(nil); m {
+		t.Errorf("Set/GetMonitoring() wrong; got %t, want %t", m, false)
+	}
+}

--- a/access/token.go
+++ b/access/token.go
@@ -1,0 +1,75 @@
+package access
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/stephen-soltesz/adhoc/jwt/token"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+// TokenController manages access control for clients providing access_token parameters.
+type TokenController struct {
+	token   *token.Verifier
+	machine string
+}
+
+const monitorIssuer = "monitoring"
+
+var (
+	tokenAccessRequests = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt_access_tokencontroller_requests_total",
+			Help: "Total number of requests handled by the access tokencontroller.",
+		},
+		[]string{"request", "protocol"},
+	)
+)
+
+// Limit implements the Controller interface by checking clients provided access_tokens.
+func (t *TokenController) Limit(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		verified, ctx := t.isVerified(r)
+		if !verified {
+			// 403 - https://tools.ietf.org/html/rfc7231#section-6.5.3
+			w.WriteHeader(http.StatusUnauthorized)
+			// Return without additional response.
+			return
+		}
+		// Clone the request with the context provided by isVerified.
+		next.ServeHTTP(w, r.Clone(ctx))
+	})
+}
+
+// isVerified validates the access_token and if the access token issuer is
+// monitoring, add a context value derived from the given request context.
+func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
+	ctx := r.Context()
+	token := r.Form.Get("access_token")
+	if token == "" {
+		// TODO: after migrating clients to locate service, require access_token.
+		// For now, accept the request.
+		tokenAccessRequests.WithLabelValues("accepted").Inc()
+		return true, ctx
+	}
+	// Attempt to verify the token.
+	cl, err := t.token.Verify(token, jwt.Expected{
+		// Do not specify the Issuer here so we can check for monitoring or the
+		// locate service below.
+		Subject:  "ndt",
+		Audience: jwt.Audience{t.machine}, // current server.
+		Time:     time.Now(),
+	})
+	if err != nil {
+		// The access token was invalid; reject this request.
+		tokenAccessRequests.WithLabelValues("rejected").Inc()
+		return false, ctx
+	}
+	// If the claim was for monitoring, set the context value so subsequent access
+	// controllers can check the advisory information to exepmpt the request.
+	tokenAccessRequests.WithLabelValues("accepted").Inc()
+	return true, SetMonitoring(ctx, cl.Issuer == monitorIssuer)
+}

--- a/access/token_test.go
+++ b/access/token_test.go
@@ -1,0 +1,120 @@
+package access
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+type fakeVerifier struct {
+	claims *jwt.Claims
+	err    error
+}
+
+func (f *fakeVerifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, error) {
+	return f.claims, f.err
+}
+
+func TestTokenController_Limit(t *testing.T) {
+	tests := []struct {
+		name       string
+		machine    string
+		verifier   *fakeVerifier
+		token      string
+		code       int
+		visited    bool
+		monitoring bool
+		wantErr    bool
+	}{
+		{
+			name:    "success-without-token",
+			machine: "mlab1.fake0",
+			verifier: &fakeVerifier{
+				claims: &jwt.Claims{
+					Issuer:   monitorIssuer,
+					Subject:  "ndt",
+					Audience: []string{"mlab1.fake0"},
+					Expiry:   jwt.NewNumericDate(time.Now()),
+				},
+			},
+			code:    http.StatusOK,
+			visited: true,
+		},
+		{
+			name:    "success-with-token",
+			machine: "mlab1.fake0",
+			verifier: &fakeVerifier{
+				claims: &jwt.Claims{
+					Issuer:   "locate.measurementlab.net",
+					Subject:  "ndt",
+					Audience: []string{"mlab1.fake0"},
+					Expiry:   jwt.NewNumericDate(time.Now()),
+				},
+			},
+			token:   "this-is-a-fake-token",
+			code:    http.StatusOK,
+			visited: true,
+		},
+		{
+			name:    "success-with-token-with-monitoring-issuer",
+			machine: "mlab1.fake0",
+			verifier: &fakeVerifier{
+				claims: &jwt.Claims{
+					Issuer:   monitorIssuer,
+					Subject:  "ndt",
+					Audience: []string{"mlab1.fake0"},
+					Expiry:   jwt.NewNumericDate(time.Now()),
+				},
+			},
+			token:      "this-is-a-fake-token",
+			code:       http.StatusOK,
+			visited:    true,
+			monitoring: true, // because the Issuer == monitorIssuer.
+		},
+		{
+			name:    "error-failure-to-verify",
+			machine: "mlab1.fake0",
+			verifier: &fakeVerifier{
+				err: fmt.Errorf("fake failure to verify"),
+			},
+			token:   "this-is-a-fake-token",
+			code:    http.StatusUnauthorized,
+			visited: false, // "next" handler is never visited.
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := NewTokenController(tt.machine, tt.verifier)
+
+			visited := false
+			isMonitoring := false
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				visited = true
+				isMonitoring = GetMonitoring(req.Context())
+			})
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Form = url.Values{}
+			if tt.token != "" {
+				req.Form.Set("access_token", tt.token)
+			}
+			rw := httptest.NewRecorder()
+
+			token.Limit(next).ServeHTTP(rw, req)
+
+			if rw.Code != tt.code {
+				t.Errorf("TokenController.Limit() wrong http code; got %d, want %d", rw.Code, tt.code)
+			}
+			if visited != tt.visited {
+				t.Errorf("TokenController.Limit() wrong visited; got %t, want %t", visited, tt.visited)
+			}
+			if isMonitoring != tt.monitoring {
+				t.Errorf("TokenController.Limit() monitoring is wrong; got %t, want %t", isMonitoring, tt.monitoring)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds access.TokenController which is capable of admitting or rejecting clients based on an "access_token" HTTP parameter. This change explicitly allows monitoring to issue access_tokens, and assign a context value to the HTTP request context, so that subsequent access controllers can a) identify monitoring requests, b) allow the test even if it would ordinarily be rejected.

To provide the option of exempting monitoring clients, the TokenController should be applied first in a sequence of access controllers.

This controller is not yet enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/269)
<!-- Reviewable:end -->
