### PR TITLE
Add separate structs for ndt5 & ndt7 datatypes

### DIFF
--- a/data/result.go
+++ b/data/result.go
@@ -10,7 +10,7 @@ import (
 	"github.com/m-lab/ndt-server/ndt7/model"
 )
 
-// NDTResult is the struct that is serialized as JSON to disk as the archival
+// NDT5Result is the struct that is serialized as JSON to disk as the archival
 // record of an NDT test.
 //
 // This struct is dual-purpose. It contains the necessary data to allow joining
@@ -21,7 +21,7 @@ import (
 // WARNING: The BigQuery schema is inferred directly from this structure. To
 // preserve compatibility with historical data, never remove fields.
 // For more information see: https://github.com/m-lab/etl/issues/719
-type NDTResult struct {
+type NDT5Result struct {
 	// GitShortCommit is the Git commit (short form) of the running server code.
 	GitShortCommit string
 	// Version is the symbolic version (if any) of the running server code.
@@ -41,6 +41,25 @@ type NDTResult struct {
 	Control *control.ArchivalData `json:",omitempty"`
 	C2S     *c2s.ArchivalData     `json:",omitempty"`
 	S2C     *s2c.ArchivalData     `json:",omitempty"`
+}
+
+// NDT7Result is the struct that is serialized as JSON to disk as the archival
+// record of an NDT7 test. This is similar to, but independent from, the NDTResult.
+type NDT7Result struct {
+	// GitShortCommit is the Git commit (short form) of the running server code.
+	GitShortCommit string
+	// Version is the symbolic version (if any) of the running server code.
+	Version string
+
+	// All data members should all be self-describing. In the event of confusion,
+	// rename them to add clarity rather than adding a comment.
+	ServerIP   string
+	ServerPort int
+	ClientIP   string
+	ClientPort int
+
+	StartTime time.Time
+	EndTime   time.Time
 
 	// ndt7
 	Upload   *model.ArchivalData `json:",omitempty"`

--- a/data/result.go
+++ b/data/result.go
@@ -10,6 +10,11 @@ import (
 	"github.com/m-lab/ndt-server/ndt7/model"
 )
 
+// NDTResult is preserved for legacy compatibility with an older unified version
+// of the NDT5 and NDT7 result structures below.
+// TODO(github.com/m-lab/ndt-server/issues/260) remove this alias once no one uses it.
+type NDTResult = NDT5Result
+
 // NDT5Result is the struct that is serialized as JSON to disk as the archival
 // record of an NDT test.
 //
@@ -44,7 +49,7 @@ type NDT5Result struct {
 }
 
 // NDT7Result is the struct that is serialized as JSON to disk as the archival
-// record of an NDT7 test. This is similar to, but independent from, the NDTResult.
+// record of an NDT7 test. This is similar to, but independent from, the NDT5Result.
 type NDT7Result struct {
 	// GitShortCommit is the Git commit (short form) of the running server code.
 	GitShortCommit string

--- a/ndt5/ndt5.go
+++ b/ndt5/ndt5.go
@@ -38,7 +38,7 @@ const (
 )
 
 // SaveData archives the data to disk.
-func SaveData(record *data.NDTResult, datadir string) {
+func SaveData(record *data.NDT5Result, datadir string) {
 	if record == nil {
 		log.Println("nil record won't be saved")
 		return
@@ -137,7 +137,7 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server) {
 	connType := s.ConnectionType().String()
 	sIP, sPort := conn.ServerIPAndPort()
 	cIP, cPort := conn.ClientIPAndPort()
-	record := &data.NDTResult{
+	record := &data.NDT5Result{
 		GitShortCommit: prometheusx.GitShortCommit,
 		Version:        version.Version,
 		StartTime:      time.Now(),

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -87,7 +87,7 @@ func (h Handler) downloadOrUpload(writer http.ResponseWriter, request *http.Requ
 	if !ok {
 		serverAddr = &net.TCPAddr{IP: net.ParseIP("::1"), Port: 1}
 	}
-	result := &data.NDTResult{
+	result := &data.NDT7Result{
 		GitShortCommit: prometheusx.GitShortCommit,
 		Version:        version.Version,
 		ClientIP:       clientAddr.IP.String(),
@@ -99,7 +99,7 @@ func (h Handler) downloadOrUpload(writer http.ResponseWriter, request *http.Requ
 	resultfp.StartTest()
 	// Guarantee that we record an end time, even if tester panics.
 	defer func() {
-		// TODO(m-lab/ndt-server/issues/152): Simplify interface between result.File and data.NDTResult.
+		// TODO(m-lab/ndt-server/issues/152): Simplify interface between result.File and data.NDT7Result.
 		result.EndTime = time.Now()
 		resultfp.EndTest()
 		if kind == spec.SubtestDownload {


### PR DESCRIPTION
This change separates the NDTResult struct into two NDT5 and NDT7 types.

This change does not remove any fields from the new NDT7 struct, in order to remain maximally backward compatible with existing ndt7 archived data.

From adhoc testing in sandbox by @gfr10598, we expect that the etl parse (once updated to use this new ndt5result struct) should be able to continue writing to the existing tables. However, some manual steps will be necessary to fix the existing table schemas before `etl/cmd/update-schema` works as intended for the ndt5 tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/271)
<!-- Reviewable:end -->
