### PR TITLE
Add monitoring label to TestRate histogram

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,6 +24,6 @@ var (
 				100, 150, 250, 400, 600,
 				1000},
 		},
-		[]string{"protocol", "direction"},
+		[]string{"protocol", "direction", "monitoring"},
 	)
 )

--- a/ndt5/handler/wshandler.go
+++ b/ndt5/handler/wshandler.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
 
+	"github.com/m-lab/access/controller"
 	"github.com/m-lab/go/warnonerror"
 	"github.com/m-lab/ndt-server/ndt5"
 	"github.com/m-lab/ndt-server/ndt5/ndt"
@@ -64,7 +66,8 @@ func (s *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	ws := protocol.AdaptWsConn(wsc)
 	defer warnonerror.Close(ws, "Could not close connection")
-	ndt5.HandleControlChannel(ws, s)
+	isMon := fmt.Sprintf("%t", controller.IsMonitoring(controller.GetClaim(r.Context())))
+	ndt5.HandleControlChannel(ws, s, isMon)
 }
 
 // NewWS returns a handler suitable for http-based connections.

--- a/ndt5/plain/plain.go
+++ b/ndt5/plain/plain.go
@@ -122,7 +122,7 @@ func (ps *plainServer) sniffThenHandle(ctx context.Context, conn net.Conn) {
 	if n != len(kickoff) || err != nil {
 		log.Printf("Could not write %d byte kickoff string: %d bytes written err: %v\n", len(kickoff), n, err)
 	}
-	ndt5.HandleControlChannel(protocol.AdaptNetConn(conn, input), ps)
+	ndt5.HandleControlChannel(protocol.AdaptNetConn(conn, input), ps, "false")
 }
 
 // ListenAndServe starts up the sniffing server that delegates to the

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -3,16 +3,20 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/m-lab/access/controller"
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/warnonerror"
 	"github.com/m-lab/ndt-server/data"
 	"github.com/m-lab/ndt-server/logging"
+	"github.com/m-lab/ndt-server/metrics"
 	"github.com/m-lab/ndt-server/ndt7/download"
+	"github.com/m-lab/ndt-server/ndt7/model"
 	"github.com/m-lab/ndt-server/ndt7/results"
 	"github.com/m-lab/ndt-server/ndt7/spec"
 	"github.com/m-lab/ndt-server/ndt7/upload"
@@ -97,6 +101,7 @@ func (h Handler) downloadOrUpload(writer http.ResponseWriter, request *http.Requ
 		StartTime:      time.Now(),
 	}
 	resultfp.StartTest()
+	isMon := fmt.Sprintf("%t", controller.IsMonitoring(controller.GetClaim(request.Context())))
 	// Guarantee that we record an end time, even if tester panics.
 	defer func() {
 		// TODO(m-lab/ndt-server/issues/152): Simplify interface between result.File and data.NDT7Result.
@@ -104,8 +109,16 @@ func (h Handler) downloadOrUpload(writer http.ResponseWriter, request *http.Requ
 		resultfp.EndTest()
 		if kind == spec.SubtestDownload {
 			result.Download = resultfp.Data
+			downloadMbps := downRate(result.Download.ServerMeasurements)
+			if downloadMbps > 0 {
+				metrics.TestRate.WithLabelValues("NDT7", "download", isMon).Observe(downloadMbps)
+			}
 		} else if kind == spec.SubtestUpload {
 			result.Upload = resultfp.Data
+			uploadMbps := upRate(result.Upload.ServerMeasurements)
+			if uploadMbps > 0 {
+				metrics.TestRate.WithLabelValues("NDT7", "upload", isMon).Observe(uploadMbps)
+			}
 		} else {
 			logging.Logger.Warn(string(kind) + ": data not saved")
 		}
@@ -125,4 +138,22 @@ func (h Handler) Download(writer http.ResponseWriter, request *http.Request) {
 // Upload handles the upload subtest.
 func (h Handler) Upload(writer http.ResponseWriter, request *http.Request) {
 	h.downloadOrUpload(writer, request, spec.SubtestUpload, upload.Do)
+}
+
+func upRate(m []model.Measurement) float64 {
+	var mbps float64
+	if len(m) > 0 {
+		// Convert to Mbps.
+		mbps = 8 * float64(m[len(m)-1].TCPInfo.BytesReceived) / float64(m[len(m)-1].TCPInfo.ElapsedTime)
+	}
+	return mbps
+}
+
+func downRate(m []model.Measurement) float64 {
+	var mbps float64
+	if len(m) > 0 {
+		// Convert to Mbps.
+		mbps = 8 * float64(m[len(m)-1].TCPInfo.BytesSent) / float64(m[len(m)-1].TCPInfo.ElapsedTime)
+	}
+	return mbps
 }

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -153,7 +153,7 @@ func downRate(m []model.Measurement) float64 {
 	var mbps float64
 	if len(m) > 0 {
 		// Convert to Mbps.
-		mbps = 8 * float64(m[len(m)-1].TCPInfo.BytesSent) / float64(m[len(m)-1].TCPInfo.ElapsedTime)
+		mbps = 8 * float64(m[len(m)-1].TCPInfo.BytesAcked) / float64(m[len(m)-1].TCPInfo.ElapsedTime)
 	}
 	return mbps
 }


### PR DESCRIPTION
This change adds a new label for `monitoring=true` or `monitoring=false` to the `TestRates` `ndt_test_rate_mbp` histogram metric. This change also adds rate collection for ndt7 measurements.

This change relies on earlier changes to process access tokens and recognize requests as monitoring (vs regular client requests).

Until the locate v2 service supports a monitoring resource that allocates access tokens to use in the e2e monitoring, the e2e measurements will not be correctly identified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/276)
<!-- Reviewable:end -->
