### PR TITLE
Label ndt5 and ndt7 test rates based on ws or wss protocol

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -163,7 +163,9 @@ func main() {
 	ndt7Mux.HandleFunc("/", defaultHandler)
 	ndt7Mux.Handle("/static/", http.StripPrefix("/static", http.FileServer(http.Dir("html"))))
 	ndt7Handler := &handler.Handler{
-		DataDir: *dataDir,
+		DataDir:      *dataDir,
+		SecurePort:   *ndt7Addr,
+		InsecurePort: *ndt7AddrCleartext,
 	}
 	ndt7Mux.Handle(spec.DownloadURLPath, http.HandlerFunc(ndt7Handler.Download))
 	ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))

--- a/ndt5/ndt5.go
+++ b/ndt5/ndt5.go
@@ -126,6 +126,22 @@ func HandleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) 
 	}()
 	handleControlChannel(conn, s, isMon)
 }
+
+// connToProtocol accepts a ConnectionType string and returns a suitable label
+// for montitoring metrics.
+func connToProtocol(connType string) string {
+	switch connType {
+	case ndt.WSS.String():
+		return "ndt5+wss"
+	case ndt.WS.String():
+		return "ndt5+ws"
+	case ndt.Plain.String():
+		return "ndt5+plain"
+	default:
+		return "ndt5+unknown"
+	}
+}
+
 func handleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) {
 	// Nothing should take more than 45 seconds, and exiting this method should
 	// cause all resources used by the test to be reclaimed.
@@ -217,7 +233,7 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) 
 		record.C2S, err = c2s.ManageTest(ctx, conn, s)
 		if record.C2S != nil && record.C2S.MeanThroughputMbps != 0 {
 			c2sRate = record.C2S.MeanThroughputMbps
-			metrics.TestRate.WithLabelValues(connType, "c2s", isMon).Observe(c2sRate)
+			metrics.TestRate.WithLabelValues(connToProtocol(connType), "c2s", isMon).Observe(c2sRate)
 		}
 		r := getResultLabel(err, record.C2S.MeanThroughputMbps)
 		ndt5metrics.ClientTestResults.WithLabelValues(connType, "c2s", r).Inc()
@@ -227,7 +243,7 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) 
 		record.S2C, err = s2c.ManageTest(ctx, conn, s)
 		if record.S2C != nil && record.S2C.MeanThroughputMbps != 0 {
 			s2cRate = record.S2C.MeanThroughputMbps
-			metrics.TestRate.WithLabelValues(connType, "s2c", isMon).Observe(s2cRate)
+			metrics.TestRate.WithLabelValues(connToProtocol(connType), "s2c", isMon).Observe(s2cRate)
 		}
 		r := getResultLabel(err, record.S2C.MeanThroughputMbps)
 		ndt5metrics.ClientTestResults.WithLabelValues(connType, "s2c", r).Inc()


### PR DESCRIPTION
This change fixes https://github.com/m-lab/ndt-server/issues/278

This change adds support for distinguishing ndt5 and ndt7 protocols in the TestRates prometheus metric.

This change will break historical continuity for the ndt5 protocol labels. The following translations will appear in the metrics upon deployment.

* WS -> ndt5+ws
* WSS -> ndt5+wss
* PLAIN -> ndt5+plain

This change adds distinct protocol values for secure and insecure ndt7 connections:

* ndt7+ws
* ndt7+wss

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/279)
<!-- Reviewable:end -->
