### PR TITLE
Attempts to fix a small race condition in setting that.results.c2sRate.

### DIFF
--- a/html/ndt-browser-client.js
+++ b/html/ndt-browser-client.js
@@ -255,7 +255,11 @@ NDTjs.prototype.ndtC2sTest = function () {
         testConnection.send(dataToSend);
         totalSent += dataToSend.length;
       }
-      if (that.updateInterval && currentTime > (testStart + nextCallback)) {
+      // Subtracting 0.1s from currentTime below ensures that this expression
+      // will always evaluate to false just a tiny bit before 10s, which
+      // eliminates a race condition between setting that.results.c2sRate
+      // here and further down in this code.
+      if (that.updateInterval && (currentTime - 0.1) > (testStart + nextCallback)) {
         that.results.c2sRate = 8 * (totalSent - testConnection.bufferedAmount)
           / 1000 / (currentTime - testStart);
         that.callbacks.onprogress('interval_c2s', that.results);


### PR DESCRIPTION
This PR attempts to resolve issue #281.

Test was done here:

https://ndt-iupui-mlab1-lga0t.mlab-sandbox.measurement-lab.org/static/widget.html

This was tested by logging into the ndt-server container on that node (mlab1-lga0t) and manually modifying `html/ndt-browser-client.js` in the running instance. Previously this bug would manifest within 4 or 5 runs. With this modification I was unable to trigger the bug in 10 or 15 runs.

The bug is identifiable by clicking on the "Advanced" tab and finding a floating point value for `c2sRate`, which should always be an integer (the server only sends an integer).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/283)
<!-- Reviewable:end -->
