### PR TITLE
Make FillUntil errors non-fatal

### DIFF
--- a/ndt5/protocol/protocol.go
+++ b/ndt5/protocol/protocol.go
@@ -181,7 +181,6 @@ func AdaptWsConn(ws *websocket.Conn) MeasuredConnection {
 }
 
 func (ws *wsConnection) FillUntil(t time.Time, bytes []byte) (bytesWritten int64, err error) {
-	ws.SetWriteDeadline(t)
 	messageToSend, err := websocket.NewPreparedMessage(websocket.BinaryMessage, bytes)
 	if err != nil {
 		return 0, err
@@ -275,7 +274,6 @@ func (nc *netConnection) ReadBytes() (bytesRead int64, err error) {
 }
 
 func (nc *netConnection) FillUntil(t time.Time, bytes []byte) (bytesWritten int64, err error) {
-	nc.SetWriteDeadline(t)
 	for time.Now().Before(t) {
 		n, err := nc.Write(bytes)
 		if err != nil {

--- a/ndt5/protocol/protocol.go
+++ b/ndt5/protocol/protocol.go
@@ -181,6 +181,7 @@ func AdaptWsConn(ws *websocket.Conn) MeasuredConnection {
 }
 
 func (ws *wsConnection) FillUntil(t time.Time, bytes []byte) (bytesWritten int64, err error) {
+	ws.SetWriteDeadline(t)
 	messageToSend, err := websocket.NewPreparedMessage(websocket.BinaryMessage, bytes)
 	if err != nil {
 		return 0, err
@@ -274,6 +275,7 @@ func (nc *netConnection) ReadBytes() (bytesRead int64, err error) {
 }
 
 func (nc *netConnection) FillUntil(t time.Time, bytes []byte) (bytesWritten int64, err error) {
+	nc.SetWriteDeadline(t)
 	for time.Now().Before(t) {
 		n, err := nc.Write(bytes)
 		if err != nil {

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -95,13 +95,8 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 
 	testConn.StartMeasuring(localCtx)
 	record.StartTime = time.Now()
-	_, err = testConn.FillUntil(time.Now().Add(10*time.Second), dataToSend)
+	testConn.FillUntil(time.Now().Add(10*time.Second), dataToSend)
 	record.EndTime = time.Now()
-	if err != nil {
-		warnonerror.Close(testConn, "Could not close test connection")
-		log.Println("Could not FillUntil", err, record.UUID)
-		// NOTE: Fall through. This is not a fatal error.
-	}
 
 	web100metrics, err := testConn.StopMeasuring()
 	if err != nil {

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -100,8 +100,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	if err != nil {
 		warnonerror.Close(testConn, "Could not close test connection")
 		log.Println("Could not FillUntil", err, record.UUID)
-		metrics.ClientTestErrors.WithLabelValues(connType, "s2c", "FillUntil").Inc()
-		return record, err
+		// NOTE: Fall through. This is not a fatal error.
 	}
 
 	web100metrics, err := testConn.StopMeasuring()
@@ -143,7 +142,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 		log.Println("Could not receive a TestMsg", err, record.UUID)
 		return record, err
 	}
-	log.Println("We measured", kbps, "and the client sent us", clientRateMsg)
+	log.Println("We measured", kbps, "and the client sent us", string(clientRateMsg))
 	clientRateKbps, err := strconv.ParseFloat(string(clientRateMsg), 64)
 	if err == nil {
 		record.ClientReportedMbps = clientRateKbps / 1000


### PR DESCRIPTION
While investigating a higher than expected error rate from the throttled ndt5-client used in the e2e monitoring with access tokens, I discovered that the cause of failure from the client perspective was the server handling `FillUntil` errors as fatal.

[FillUntil in prometheus metrics][prom] is the second most frequent error from clients. In the case of the ndt5-client, the error is a result of two steps:

* a slow client causes the ndt-server to stall in [`ws.WritePreparedMessage()` ][write].
* the client adds a timeout of [15sec to testconn][timeout], and the [downloader goroutine][downloader] runs until a read error or timeout.

After the 15sec timeout, the client closes the test connection. Because the server was blocked in a write, the write returns an error and returns from FillUntil. When the server aborts the test, the client also registers a failure.

This PR prevents that failure by ignoring the FillUntil error and continuing to collect connection metrics and sending them to the client via the control channel. If the client has truly disconnected, there are additional opportunities for error: sending results, receiving client performance, sending all metrics, sending test finalize.

[downloader]: https://github.com/m-lab/ndt5-client-go/blob/master/client.go#L540-L561
[timeout]: https://github.com/m-lab/ndt5-client-go/blob/master/client.go#L479
[write]: https://github.com/m-lab/ndt-server/blob/master/ndt5/protocol/protocol.go#L189
[prom]: https://mlab:o7e8PR29aMt17JLPlX2yd@prometheus-platform-cluster.mlab-oti.measurementlab.net/graph?g0.range_input=2w&g0.expr=sum%20by%20(error)%20(increase(ndt5_client_test_errors_total%7Bdirection%3D%22s2c%22%2C%20protocol%3D%22WSS%22%7D%5B1h%5D))&g0.tab=0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/285)
<!-- Reviewable:end -->
