### PR TITLE
Add support for loading multiple verify keys

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -37,7 +37,7 @@ var (
 	certFile          = flag.String("cert", "", "The file with server certificates in PEM format.")
 	keyFile           = flag.String("key", "", "The file with server key in PEM format.")
 	dataDir           = flag.String("datadir", "/var/spool/ndt", "The directory in which to write data files")
-	tokenVerifyKey    = flagx.FileBytes{}
+	tokenVerifyKey    = flagx.FileBytesArray{}
 	tokenRequired5    bool
 	tokenRequired7    bool
 	tokenMachine      string
@@ -131,7 +131,7 @@ func main() {
 	// to be optional for users who have no need for access tokens. An invalid
 	// verifier is handled safely by Setup and only prints a warning when access
 	// token verification is disabled.
-	v, err := token.NewVerifier(tokenVerifyKey)
+	v, err := token.NewVerifier(tokenVerifyKey.Get()...)
 	if (tokenRequired5 || tokenRequired7) && err != nil {
 		rtx.Must(err, "Failed to load verifier for when tokens are required")
 	}


### PR DESCRIPTION
This change is a backward compatible update to the `-token.verify-key` flag of the ndt-server. This change will now allow caller to provide multiple verify keys in order to allow key rotation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/288)
<!-- Reviewable:end -->
