### PR TITLE
Add metrics shared with clients to ArchivalData

### DIFF
--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -260,13 +260,13 @@ func Test_MainIntegrationTest(t *testing.T) {
 		// Test NDT7 clients
 		{
 			name: "Test the ndt7 protocol",
-			cmd:  "timeout 45s ndt7-client -no-verify -hostname localhost:" + ndt7Addr,
+			cmd:  "timeout 45s ndt7-client -no-verify -server localhost:" + ndt7Addr,
 			// Ignore data because Travis does not support BBR.  Once Travis does support BBR, delete this.
 			ignoreData: true,
 		},
 		{
 			name: "Test the ndt7 protocol in cleartext",
-			cmd:  "timeout 45s ndt7-client -scheme ws -hostname localhost:" + ndt7AddrCleartext,
+			cmd:  "timeout 45s ndt7-client -scheme ws -server localhost:" + ndt7AddrCleartext,
 			// Ignore data because Travis does not support BBR.  Once Travis does support BBR, delete this.
 			ignoreData: true,
 		},

--- a/ndt5/c2s/c2s.go
+++ b/ndt5/c2s/c2s.go
@@ -31,6 +31,7 @@ type ArchivalData struct {
 	StartTime          time.Time
 	EndTime            time.Time
 	MeanThroughputMbps float64
+	MinRTT             time.Duration
 	// TODO: Add TCPEngine (bbr, cubic, reno, etc.)
 
 	Error string `json:",omitempty"`
@@ -94,13 +95,13 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	}
 
 	record.StartTime = time.Now()
-	byteCount, err := drainForeverButMeasureFor(ctx, testConn, 10*time.Second)
+	web100Metrics, err := drainForeverButMeasureFor(ctx, testConn, 10*time.Second)
 	record.EndTime = time.Now()
 	seconds := record.EndTime.Sub(record.StartTime).Seconds()
 	log.Println("Ended C2S test on", testConn, record.UUID)
 	if err != nil {
-		if byteCount == 0 {
-			log.Println("Could not drain the test connection", byteCount, err, record.UUID)
+		if web100Metrics.TCPInfo.BytesReceived == 0 {
+			log.Println("Could not drain the test connection", err, record.UUID)
 			metrics.ClientTestErrors.WithLabelValues(connType, "c2s", "Drain").Inc()
 			return record, err
 		}
@@ -114,8 +115,9 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 		log.Printf("C2S test had an error (%v) after %f seconds. We will continue with the test.\n", err, seconds)
 	}
 
-	throughputValue := 8 * float64(byteCount) / 1000 / seconds
+	throughputValue := 8 * float64(web100Metrics.TCPInfo.BytesReceived) / 1000 / seconds
 	record.MeanThroughputMbps = throughputValue / 1000 // Convert Kbps to Mbps
+	record.MinRTT = time.Duration(web100Metrics.MinRTT) * time.Millisecond
 
 	log.Println(controlConn, "sent us", throughputValue, "Kbps")
 	err = m.SendMessage(protocol.TestMsg, []byte(strconv.FormatInt(int64(throughputValue), 10)))
@@ -139,7 +141,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 // measuring the connection for the first part of the drain. This method does
 // not close the passed-in Connection, and starts a goroutine which runs until
 // that Connection is closed.
-func drainForeverButMeasureFor(ctx context.Context, conn protocol.MeasuredConnection, d time.Duration) (int64, error) {
+func drainForeverButMeasureFor(ctx context.Context, conn protocol.MeasuredConnection, d time.Duration) (*web100.Metrics, error) {
 	derivedCtx, derivedCancel := context.WithTimeout(ctx, d)
 	defer derivedCancel()
 
@@ -169,9 +171,9 @@ func drainForeverButMeasureFor(ctx context.Context, conn protocol.MeasuredConnec
 		socketStats, _ = conn.StopMeasuring()
 	}
 	if socketStats == nil {
-		return 0, err
+		return nil, err
 	}
 	// The TCPInfo element of socketstats is a value not a pointer, so this is safe
 	// if socketStats is not nil.
-	return socketStats.TCPInfo.BytesReceived, err
+	return socketStats, err
 }

--- a/ndt5/c2s/c2s.go
+++ b/ndt5/c2s/c2s.go
@@ -31,8 +31,6 @@ type ArchivalData struct {
 	StartTime          time.Time
 	EndTime            time.Time
 	MeanThroughputMbps float64
-	MinRTT             time.Duration
-	MaxRTT             time.Duration
 	// TODO: Add TCPEngine (bbr, cubic, reno, etc.)
 
 	Error string `json:",omitempty"`
@@ -118,8 +116,6 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 
 	throughputValue := 8 * float64(web100Metrics.TCPInfo.BytesReceived) / 1000 / seconds
 	record.MeanThroughputMbps = throughputValue / 1000 // Convert Kbps to Mbps
-	record.MinRTT = time.Duration(web100Metrics.MinRTT) * time.Millisecond
-	record.MaxRTT = time.Duration(web100Metrics.MaxRTT) * time.Millisecond
 
 	log.Println(controlConn, "sent us", throughputValue, "Kbps")
 	err = m.SendMessage(protocol.TestMsg, []byte(strconv.FormatInt(int64(throughputValue), 10)))

--- a/ndt5/c2s/c2s.go
+++ b/ndt5/c2s/c2s.go
@@ -32,6 +32,7 @@ type ArchivalData struct {
 	EndTime            time.Time
 	MeanThroughputMbps float64
 	MinRTT             time.Duration
+	MaxRTT             time.Duration
 	// TODO: Add TCPEngine (bbr, cubic, reno, etc.)
 
 	Error string `json:",omitempty"`
@@ -118,6 +119,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	throughputValue := 8 * float64(web100Metrics.TCPInfo.BytesReceived) / 1000 / seconds
 	record.MeanThroughputMbps = throughputValue / 1000 // Convert Kbps to Mbps
 	record.MinRTT = time.Duration(web100Metrics.MinRTT) * time.Millisecond
+	record.MaxRTT = time.Duration(web100Metrics.MaxRTT) * time.Millisecond
 
 	log.Println(controlConn, "sent us", throughputValue, "Kbps")
 	err = m.SendMessage(protocol.TestMsg, []byte(strconv.FormatInt(int64(throughputValue), 10)))

--- a/ndt5/c2s/c2s.go
+++ b/ndt5/c2s/c2s.go
@@ -171,7 +171,6 @@ func drainForeverButMeasureFor(ctx context.Context, conn protocol.MeasuredConnec
 	if socketStats == nil {
 		return nil, err
 	}
-	// The TCPInfo element of socketstats is a value not a pointer, so this is safe
-	// if socketStats is not nil.
+	// socketStats is guaranteed to be non-nil and the TCPInfo element is a value not a pointer.
 	return socketStats, err
 }

--- a/ndt5/c2s/c2s_test.go
+++ b/ndt5/c2s/c2s_test.go
@@ -48,12 +48,12 @@ func Test_DrainForeverButMeasureFor_NormalOperation(t *testing.T) {
 		}
 		cConn.Close()
 	}()
-	count, err := drainForeverButMeasureFor(ctx, sConn, time.Duration(100*time.Millisecond))
+	metrics, err := drainForeverButMeasureFor(ctx, sConn, time.Duration(100*time.Millisecond))
 	if err != nil {
 		t.Error("Should not have gotten error:", err)
 	}
-	if count <= 0 {
-		t.Errorf("Expected positive byte count but got %d", count)
+	if metrics.TCPInfo.BytesReceived <= 0 {
+		t.Errorf("Expected positive byte count but got %d", metrics.TCPInfo.BytesReceived)
 	}
 }
 
@@ -69,12 +69,12 @@ func Test_DrainForeverButMeasureFor_EarlyClientQuit(t *testing.T) {
 		time.Sleep(100 * time.Millisecond) // Give the drainForever process time to get going
 		cConn.Close()
 	}()
-	count, err := drainForeverButMeasureFor(ctx, sConn, time.Duration(1*time.Second))
+	metrics, err := drainForeverButMeasureFor(ctx, sConn, time.Duration(1*time.Second))
 	if err == nil {
 		t.Error("Should have gotten an error")
 	}
-	if count <= 0 {
-		t.Errorf("Expected positive byte count but got %d", count)
+	if metrics.TCPInfo.BytesReceived <= 0 {
+		t.Errorf("Expected positive byte count but got %d", metrics.TCPInfo.BytesReceived)
 	}
 }
 
@@ -112,11 +112,11 @@ func Test_DrainForeverButMeasureFor_CountsAllBytesNotJustWsGoodput(t *testing.T)
 		<-ctx2.Done()
 		cConn.Close()
 	}()
-	count, err := drainForeverButMeasureFor(ctx, sConn, time.Duration(1*time.Millisecond))
+	metrics, err := drainForeverButMeasureFor(ctx, sConn, time.Duration(1*time.Millisecond))
 	if err != nil {
 		t.Error("Should not have gotten error:", err)
 	}
-	if count <= 0 {
-		t.Errorf("Expected positive byte count but got %d", count)
+	if metrics.TCPInfo.BytesReceived <= 0 {
+		t.Errorf("Expected positive byte count but got %d", metrics.TCPInfo.BytesReceived)
 	}
 }

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -11,6 +11,7 @@ import (
 	"github.com/m-lab/ndt-server/ndt5/metrics"
 	"github.com/m-lab/ndt-server/ndt5/ndt"
 	"github.com/m-lab/ndt-server/ndt5/protocol"
+	"github.com/m-lab/tcp-info/tcp"
 )
 
 // ArchivalData is the data saved by the S2C test. If a researcher wants deeper
@@ -35,11 +36,14 @@ type ArchivalData struct {
 	MeanThroughputMbps float64
 	MinRTT             time.Duration
 	MaxRTT             time.Duration
+	SumRTT             time.Duration
+	CountRTT           uint32
 	LossRate           float64
 	ClientReportedMbps float64
 	// TODO: Add TCPEngine (bbr, cubic, reno, etc.), MaxThroughputKbps, and Jitter
 
-	Error string `json:",omitempty"`
+	TCPInfo *tcp.LinuxTCPInfo `json:",omitempty"`
+	Error   string            `json:",omitempty"`
 }
 
 // ManageTest manages the s2c test lifecycle
@@ -123,8 +127,11 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	kbps := bps / 1000
 	record.MinRTT = time.Duration(web100metrics.MinRTT) * time.Millisecond
 	record.MaxRTT = time.Duration(web100metrics.MaxRTT) * time.Millisecond
+	record.SumRTT = time.Duration(web100metrics.SumRTT) * time.Millisecond
+	record.CountRTT = web100metrics.CountRTT
 	record.MeanThroughputMbps = kbps / 1000 // Convert Kbps to Mbps
 	record.LossRate = float64(web100metrics.TCPInfo.BytesRetrans) / float64(web100metrics.TCPInfo.BytesSent)
+	record.TCPInfo = &web100metrics.TCPInfo
 
 	// Send download results to the client.
 	err = m.SendS2CResults(int64(kbps), 0, web100metrics.TCPInfo.BytesAcked)

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -34,6 +34,7 @@ type ArchivalData struct {
 	EndTime            time.Time
 	MeanThroughputMbps float64
 	MinRTT             time.Duration
+	MaxRTT             time.Duration
 	LossRate           float64
 	ClientReportedMbps float64
 	// TODO: Add TCPEngine (bbr, cubic, reno, etc.), MaxThroughputKbps, and Jitter
@@ -121,6 +122,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	bps := 8 * float64(web100metrics.TCPInfo.BytesAcked) / record.EndTime.Sub(record.StartTime).Seconds()
 	kbps := bps / 1000
 	record.MinRTT = time.Duration(web100metrics.MinRTT) * time.Millisecond
+	record.MaxRTT = time.Duration(web100metrics.MaxRTT) * time.Millisecond
 	record.MeanThroughputMbps = kbps / 1000 // Convert Kbps to Mbps
 	record.LossRate = float64(web100metrics.TCPInfo.BytesRetrans) / float64(web100metrics.TCPInfo.BytesSent)
 

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -34,6 +34,7 @@ type ArchivalData struct {
 	EndTime            time.Time
 	MeanThroughputMbps float64
 	MinRTT             time.Duration
+	LossRate           float64
 	ClientReportedMbps float64
 	// TODO: Add TCPEngine (bbr, cubic, reno, etc.), MaxThroughputKbps, and Jitter
 
@@ -121,6 +122,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	kbps := bps / 1000
 	record.MinRTT = time.Duration(web100metrics.MinRTT) * time.Millisecond
 	record.MeanThroughputMbps = kbps / 1000 // Convert Kbps to Mbps
+	record.LossRate = float64(web100metrics.TCPInfo.BytesRetrans) / float64(web100metrics.TCPInfo.BytesSent)
 
 	// Send download results to the client.
 	err = m.SendS2CResults(int64(kbps), 0, web100metrics.TCPInfo.BytesAcked)

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -38,7 +38,6 @@ type ArchivalData struct {
 	MaxRTT             time.Duration
 	SumRTT             time.Duration
 	CountRTT           uint32
-	LossRate           float64
 	ClientReportedMbps float64
 	// TODO: Add TCPEngine (bbr, cubic, reno, etc.), MaxThroughputKbps, and Jitter
 
@@ -130,7 +129,6 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	record.SumRTT = time.Duration(web100metrics.SumRTT) * time.Millisecond
 	record.CountRTT = web100metrics.CountRTT
 	record.MeanThroughputMbps = kbps / 1000 // Convert Kbps to Mbps
-	record.LossRate = float64(web100metrics.TCPInfo.BytesRetrans) / float64(web100metrics.TCPInfo.BytesSent)
 	record.TCPInfo = &web100metrics.TCPInfo
 
 	// Send download results to the client.

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -95,14 +95,8 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 
 	testConn.StartMeasuring(localCtx)
 	record.StartTime = time.Now()
-	_, err = testConn.FillUntil(time.Now().Add(10*time.Second), dataToSend)
+	testConn.FillUntil(time.Now().Add(10*time.Second), dataToSend)
 	record.EndTime = time.Now()
-	if err != nil {
-		warnonerror.Close(testConn, "Could not close test connection")
-		log.Println("Could not FillUntil", err, record.UUID)
-		metrics.ClientTestErrors.WithLabelValues(connType, "s2c", "FillUntil").Inc()
-		return record, err
-	}
 
 	web100metrics, err := testConn.StopMeasuring()
 	if err != nil {
@@ -143,7 +137,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 		log.Println("Could not receive a TestMsg", err, record.UUID)
 		return record, err
 	}
-	log.Println("We measured", kbps, "and the client sent us", clientRateMsg)
+	log.Println("We measured", kbps, "and the client sent us", string(clientRateMsg))
 	clientRateKbps, err := strconv.ParseFloat(string(clientRateMsg), 64)
 	if err == nil {
 		record.ClientReportedMbps = clientRateKbps / 1000


### PR DESCRIPTION
While working on the ndt5 parser migration to standard columns, I discovered that we are not collecting some metrics in the ndt5 archival structure.

This change adds two new values to the s2c and c2s archival data: LossRate and MinRTT respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/289)
<!-- Reviewable:end -->
