### PR TITLE
Add metrics to ndt7 server and netx.Conns

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,3 +27,18 @@ var (
 		[]string{"protocol", "direction", "monitoring"},
 	)
 )
+
+// GetResultLabel returns one of four strings based on the combination of
+// whether the error ("okay" or "error") and the rate ("with-rate" (non-zero) or
+// "without-rate" (zero)).
+func GetResultLabel(err error, rate float64) string {
+	withErr := "okay"
+	if err != nil {
+		withErr = "error"
+	}
+	withResult := "-with-rate"
+	if rate == 0 {
+		withResult = "-without-rate"
+	}
+	return withErr + withResult
+}

--- a/ndt5/ndt5.go
+++ b/ndt5/ndt5.go
@@ -87,18 +87,6 @@ func panicMsgToErrType(msg string) string {
 	return "panic"
 }
 
-func getResultLabel(err error, rate float64) string {
-	withErr := "okay"
-	if err != nil {
-		withErr = "error"
-	}
-	withResult := "-with-rate"
-	if rate == 0 {
-		withResult = "-without-rate"
-	}
-	return withErr + withResult
-}
-
 // HandleControlChannel is the "business logic" of an NDT test. It is designed
 // to run every test, and to never need to know whether the underlying
 // connection is just a TCP socket, a WS connection, or a WSS connection. It
@@ -235,7 +223,7 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) 
 			c2sRate = record.C2S.MeanThroughputMbps
 			metrics.TestRate.WithLabelValues(connToProtocol(connType), "c2s", isMon).Observe(c2sRate)
 		}
-		r := getResultLabel(err, record.C2S.MeanThroughputMbps)
+		r := metrics.GetResultLabel(err, record.C2S.MeanThroughputMbps)
 		ndt5metrics.ClientTestResults.WithLabelValues(connType, "c2s", r).Inc()
 		rtx.PanicOnError(err, "C2S - Could not run c2s test (uuid: %s)", record.Control.UUID)
 	}
@@ -245,7 +233,7 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) 
 			s2cRate = record.S2C.MeanThroughputMbps
 			metrics.TestRate.WithLabelValues(connToProtocol(connType), "s2c", isMon).Observe(s2cRate)
 		}
-		r := getResultLabel(err, record.S2C.MeanThroughputMbps)
+		r := metrics.GetResultLabel(err, record.S2C.MeanThroughputMbps)
 		ndt5metrics.ClientTestResults.WithLabelValues(connType, "s2c", r).Inc()
 		rtx.PanicOnError(err, "S2C - Could not run s2c test (uuid: %s)", record.Control.UUID)
 	}

--- a/ndt7/download/download.go
+++ b/ndt7/download/download.go
@@ -14,7 +14,7 @@ import (
 // for the subtest. The conn argument is the open WebSocket connection. The data
 // argument is the archival data where results are saved. All arguments are
 // owned by the caller of this function.
-func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) {
+func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) error {
 	// Implementation note: use child contexts so the sender is strictly time
 	// bounded. After timeout, the sender closes the conn, which results in the
 	// receiver completing.
@@ -24,8 +24,9 @@ func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) {
 
 	// Perform download and save server-measurements in data.
 	// TODO: move sender.Start logic to this file.
-	sender.Start(ctx, conn, data)
+	err := sender.Start(ctx, conn, data)
 
 	// Block on the receiver completing to guarantee that access to data is synchronous.
 	<-recv.Done()
+	return err
 }

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -20,6 +19,7 @@ import (
 	"github.com/m-lab/ndt-server/metadata"
 	"github.com/m-lab/ndt-server/metrics"
 	"github.com/m-lab/ndt-server/ndt7/download"
+	ndt7metrics "github.com/m-lab/ndt-server/ndt7/metrics"
 	"github.com/m-lab/ndt-server/ndt7/model"
 	"github.com/m-lab/ndt-server/ndt7/results"
 	"github.com/m-lab/ndt-server/ndt7/spec"
@@ -63,22 +63,19 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	conn := setupConn(rw, req)
 	if conn == nil {
 		// TODO: test failure.
+		ndt7metrics.ClientConnections.WithLabelValues(string(kind), "websocket-error").Inc()
 		return
 	}
-	// TODO(bassosimone): an error before this point means that the *os.File
-	// will stay in cache until the cache pruning mechanism is triggered. This
-	// should be a small amount of seconds. If Golang does not call shutdown(2)
-	// and close(2), we'll end up keeping sockets that caused an error in the
-	// code above (e.g. because the handshake was not okay) alive for the time
-	// in which the corresponding *os.File is kept in cache.
 	defer warnonerror.Close(conn, "runMeasurement: ignoring conn.Close result")
-
 	// Create measurement archival data.
 	data, err := getData(conn)
 	if err != nil {
 		// TODO: test failure.
+		ndt7metrics.ClientConnections.WithLabelValues(string(kind), "uuid-error").Inc()
 		return
 	}
+	ndt7metrics.ClientConnections.WithLabelValues(string(kind), "setup-success").Inc()
+
 	// Collect most client metadata from request parameters.
 	appendClientMetadata(data, req.URL.Query())
 	// Create ultimate result.
@@ -92,26 +89,25 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	}()
 
 	// Run measurement.
+	var rate float64
 	if kind == spec.SubtestDownload {
 		result.Download = data
-		download.Do(req.Context(), conn, data)
-		h.observe(conn, req, string(kind), downRate(data.ServerMeasurements))
+		err = download.Do(req.Context(), conn, data)
+		rate = downRate(data.ServerMeasurements)
 	} else if kind == spec.SubtestUpload {
 		result.Upload = data
-		upload.Do(req.Context(), conn, data)
-		h.observe(conn, req, string(kind), upRate(data.ServerMeasurements))
+		err = upload.Do(req.Context(), conn, data)
+		rate = upRate(data.ServerMeasurements)
 	}
-}
 
-// getProtocol infers an appropriate label for the websocket protocol.
-func (h Handler) getProtocol(conn *websocket.Conn) string {
-	if strings.HasSuffix(conn.LocalAddr().String(), h.SecurePort) {
-		return "ndt7+wss"
+	proto := ndt7metrics.ConnLabel(conn)
+	ndt7metrics.ClientTestResults.WithLabelValues(
+		proto, string(kind), metrics.GetResultLabel(err, rate)).Inc()
+	if rate > 0 {
+		isMon := fmt.Sprintf("%t", controller.IsMonitoring(controller.GetClaim(req.Context())))
+		// Update the common (ndt5+ndt7) measurement rates histogram.
+		metrics.TestRate.WithLabelValues(proto, string(kind), isMon).Observe(rate)
 	}
-	if strings.HasSuffix(conn.LocalAddr().String(), h.InsecurePort) {
-		return "ndt7+ws"
-	}
-	return "ndt7+unknown"
 }
 
 // setupConn negotiates a websocket connection. The writer argument is the HTTP
@@ -162,15 +158,6 @@ func setupResult(conn *websocket.Conn) *data.NDT7Result {
 		ServerPort:     serverAddr.Port,
 	}
 	return result
-}
-
-func (h Handler) observe(conn *websocket.Conn, request *http.Request, direction string, val float64) {
-	if val > 0 {
-		isMon := fmt.Sprintf("%t", controller.IsMonitoring(controller.GetClaim(request.Context())))
-		proto := h.getProtocol(conn)
-		// Update the download rates histogram.
-		metrics.TestRate.WithLabelValues(proto, direction, isMon).Observe(val)
-	}
 }
 
 func (h Handler) writeResult(uuid string, kind spec.SubtestKind, result *data.NDT7Result) {

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -74,7 +74,8 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 		ndt7metrics.ClientConnections.WithLabelValues(string(kind), "uuid-error").Inc()
 		return
 	}
-	ndt7metrics.ClientConnections.WithLabelValues(string(kind), "setup-success").Inc()
+	// We are guaranteed to collect a result at this point (even if it's with an error)
+	ndt7metrics.ClientConnections.WithLabelValues(string(kind), "result").Inc()
 
 	// Collect most client metadata from request parameters.
 	appendClientMetadata(data, req.URL.Query())

--- a/ndt7/metrics/README.md
+++ b/ndt7/metrics/README.md
@@ -8,9 +8,10 @@ successes, and error rates for the sender and receiver.
   connection that reaches `handler.Upload` or `handler.Download`.
 
   * The "direction=" label indicates an "upload" or "download" measurement.
-  * The "status=" label is either "setup-success" or a specific error that
+  * The "status=" label is either "result" or a specific error that
     prevented setup before the connection was aborted.
-  * All status="setup-succes" results are counted in `ndt7_client_test_results_total`.
+  * All status="result" clients are counted in `ndt7_client_test_results_total`.
+  * All status="result" clients should also equal the number of files written.
 
 * `ndt7_client_test_results_total{protocol, direction, result}` counts the
   test results of clients that successfully setup the websocket connection.
@@ -34,6 +35,6 @@ successes, and error rates for the sender and receiver.
 
 Expected invariants:
 
-* `ndt7_client_connections_total{status="setup-success"} == sum(ndt7_client_test_results_total)`
+* `ndt7_client_connections_total{status="result"} == sum(ndt7_client_test_results_total)`
 * `sum(ndt7_client_test_results_total) == sum(ndt7_client_sender_errors_total)`
 * `sum(ndt7_client_test_results_total) == sum(ndt7_client_receiver_errors_total)`

--- a/ndt7/metrics/README.md
+++ b/ndt7/metrics/README.md
@@ -3,7 +3,6 @@
 Summary of ndt7 metrics useful for monitoring client requests, measurement
 successes, and error rates for the sender and receiver.
 
-
 * `ndt7_client_connections_total{direction, status}` counts every client
   connection that reaches `handler.Upload` or `handler.Download`.
 

--- a/ndt7/metrics/README.md
+++ b/ndt7/metrics/README.md
@@ -1,0 +1,39 @@
+# NDT7 Server Metrics
+
+Summary of ndt7 metrics useful for monitoring client requests, measurement
+successes, and error rates for the sender and receiver.
+
+
+* `ndt7_client_connections_total{direction, status}` counts every client
+  connection that reaches `handler.Upload` or `handler.Download`.
+
+  * The "direction=" label indicates an "upload" or "download" measurement.
+  * The "status=" label is either "setup-success" or a specific error that
+    prevented setup before the connection was aborted.
+  * All status="setup-succes" results are counted in `ndt7_client_test_results_total`.
+
+* `ndt7_client_test_results_total{protocol, direction, result}` counts the
+  test results of clients that successfully setup the websocket connection.
+
+  * The "protocol=" label indicates the "ndt7+wss" or "ndt7+ws" protocol.
+  * The "direction=" labels are as above.
+  * The "result=" label is either "okay-with-rate", "error-with-rate" or
+    "error-without-rate".
+  * All result=~"*-with-rate" measurements are also recorded in the shared
+    test rate histogram.
+  * All results are also counted in `ndt7_client_sender_errors_total` and
+    `ndt7_client_receiver_errors_total`
+
+* `ndt7_client_sender_errors_total{protocol, direction, error}`
+  * The "protocol=" and "direction=" labels are as above.
+  * The "error=" label contains unique values mapping to specific error or return
+    paths in the sender.
+
+* `ndt7_client_receiver_errors_total{protocol, direction, error}`
+  * Just like the `ndt7_client_sender_errors_total` metric, but for the receiver.
+
+Expected invariants:
+
+* `ndt7_client_connections_total{status="setup-success"} == sum(ndt7_client_test_results_total)`
+* `sum(ndt7_client_test_results_total) == sum(ndt7_client_sender_errors_total)`
+* `sum(ndt7_client_test_results_total) == sum(ndt7_client_receiver_errors_total)`

--- a/ndt7/metrics/metrics.go
+++ b/ndt7/metrics/metrics.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics for exporting to prometheus to aid in server monitoring.
+var (
+	ClientConnections = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt7_client_connections_total",
+			Help: "Count of clients that connect and setup an ndt7 measurement.",
+		},
+		[]string{"direction", "status"},
+	)
+	ClientTestResults = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt7_client_test_results_total",
+			Help: "Number of client-connections for NDT tests run by this server.",
+		},
+		[]string{"protocol", "direction", "result"},
+	)
+	ClientSenderErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt7_client_sender_errors_total",
+			Help: "Number of sender errors on all return paths.",
+		},
+		[]string{"protocol", "direction", "error"},
+	)
+	ClientReceiverErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt7_client_receiver_errors_total",
+			Help: "Number of receiver errors on all return paths.",
+		},
+		[]string{"protocol", "direction", "error"},
+	)
+)
+
+// ConnLabel infers an appropriate label for the websocket protocol.
+func ConnLabel(conn *websocket.Conn) string {
+	// NOTE: this isn't perfect, but it is simple and a) works for production deployments,
+	// and 2) will work for custom deployments with ports having the same suffix, e.g. 4433, 8080.
+	if strings.HasSuffix(conn.LocalAddr().String(), "443") {
+		return "ndt7+wss"
+	}
+	if strings.HasSuffix(conn.LocalAddr().String(), "80") {
+		return "ndt7+ws"
+	}
+	return "ndt7+unknown"
+}

--- a/ndt7/upload/upload.go
+++ b/ndt7/upload/upload.go
@@ -14,7 +14,7 @@ import (
 // the subtest. The conn argument is the open WebSocket connection. The data
 // argument is the archival data where results are saved. All arguments are
 // owned by the caller of this function.
-func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) {
+func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) error {
 	// Implementation note: use child contexts so the sender is strictly time
 	// bounded. After timeout, the sender closes the conn, which results in the
 	// receiver completing.
@@ -24,8 +24,9 @@ func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) {
 
 	// Perform upload and save server-measurements in data.
 	// TODO: move sender.Start logic to this file.
-	sender.Start(ctx, conn, data)
+	err := sender.Start(ctx, conn, data)
 
 	// Block on the receiver completing to guarantee that access to data is synchronous.
 	<-recv.Done()
+	return err
 }


### PR DESCRIPTION
This change adds metrics to instrument the ndt7 server in a similar way to the ndt5 server today. Specifically, this change adds four ndt7 specific metrics (see README for details).

* `ndt7_client_connections_total{direction, status}`
* `ndt7_client_test_results_total{protocol, direction, result}`
* `ndt7_client_sender_errors_total{protocol, direction, error}`
* `ndt7_client_receiver_errors_total{protocol, direction, error}`

This change also introduces a simple gauge to count the number of currently open netx.Conn file pointers. This will aid it detecting potential leaks, or simply reporting the current number of open connections to the server.

* `netx_current_open_conns`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/298)
<!-- Reviewable:end -->
