### PR TITLE
Fix netx.Conn metrics and reduce ndt7 websocket buffer

### DIFF
--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -126,8 +126,8 @@ func setupConn(writer http.ResponseWriter, request *http.Request) *websocket.Con
 		CheckOrigin: func(r *http.Request) bool {
 			return true // Allow cross origin resource sharing
 		},
-		ReadBufferSize:  spec.MaxMessageSize,
-		WriteBufferSize: spec.MaxMessageSize,
+		ReadBufferSize:  spec.DefaultWebsocketBufferSize,
+		WriteBufferSize: spec.DefaultWebsocketBufferSize,
 	}
 	conn, err := upgrader.Upgrade(writer, request, headers)
 	if err != nil {

--- a/ndt7/spec/spec.go
+++ b/ndt7/spec/spec.go
@@ -22,6 +22,13 @@ const MaxMessageSize = 1 << 24
 // a good compromise between Go and JavaScript as seen in cloud based tests.
 const MaxScaledMessageSize = 1 << 20
 
+// DefaultWebsocketBufferSize is the read and write buffer sizes used when
+// creating a websocket connection. This size is independent of the websocket
+// message sizes defined above (which may be larger) and used to optimize read
+// and write operations. However, larger buffers will practically limit the
+// total number of concurrent connections possible.
+const DefaultWebsocketBufferSize = 1 << 20
+
 // ScalingFraction sets the threshold for scaling binary messages. When
 // the current binary message size is <= than 1/scalingFactor of the
 // amount of bytes sent so far, we scale the message. This is documented

--- a/ndt7/spec/spec.go
+++ b/ndt7/spec/spec.go
@@ -26,7 +26,7 @@ const MaxScaledMessageSize = 1 << 20
 // creating a websocket connection. This size is independent of the websocket
 // message sizes defined above (which may be larger) and used to optimize read
 // and write operations. However, larger buffers will practically limit the
-// total number of concurrent connections possible.
+// total number of concurrent connections possible. We use 1MB as a balance.
 const DefaultWebsocketBufferSize = 1 << 20
 
 // ScalingFraction sets the threshold for scaling binary messages. When

--- a/netx/net.go
+++ b/netx/net.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"sync"
 	"time"
 
 	guuid "github.com/google/uuid"
@@ -51,6 +52,7 @@ type Conn struct {
 	net.Conn
 	fp      *os.File
 	netinfo iface.NetInfo
+	once    sync.Once
 }
 
 // Addr supports the net.Addr interface and allows mediated access to operations
@@ -110,7 +112,7 @@ func (ln *Listener) Accept() (net.Conn, error) {
 // returned by LocalAddr and RemoteAddr should be released before calling Close.
 func (mc *Conn) Close() error {
 	mc.fp.Close()
-	CurrentOpenConns.Dec()
+	mc.once.Do(CurrentOpenConns.Dec)
 	return mc.Conn.Close()
 }
 


### PR DESCRIPTION
During load testing, I discovered that ndt5 can close netx.Conns multiple times. This change guarantees that the metric is only decremented once.

During load testing, I discovered that ndt7 RAM requirements limit maximum concurrent connections to 1/3 ndt5's level with ndt-server RSS maxing out around 9.5GB before the system failed. This appears to be due to the extremely large websocket buffers. This change adds a new constant for the websocket buffer sizes of 1MB. Buffer sizes are independent of websocket message sizes.

With these settings load testing was able to comfortably support 300 concurrent connections (the previous water mark from NDT5) or ~1700 tests/min (very close to the theoretical limit of 1800 / min for 10sec tests, which is much tighter run time than ndt5's 15sec/test).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/299)
<!-- Reviewable:end -->
