### PR TITLE
Fix error metric increments

### DIFF
--- a/ndt7/download/sender/sender.go
+++ b/ndt7/download/sender/sender.go
@@ -49,7 +49,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 	if err != nil {
 		logging.Logger.WithError(err).Warn("sender: makePreparedMessage failed")
 		ndt7metrics.ClientSenderErrors.WithLabelValues(
-			proto, string(spec.SubtestDownload), "make-prepared-message")
+			proto, string(spec.SubtestDownload), "make-prepared-message").Inc()
 		return err
 	}
 	deadline := time.Now().Add(spec.MaxRuntime)
@@ -57,7 +57,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 	if err != nil {
 		logging.Logger.WithError(err).Warn("sender: conn.SetWriteDeadline failed")
 		ndt7metrics.ClientSenderErrors.WithLabelValues(
-			proto, string(spec.SubtestDownload), "set-write-deadline")
+			proto, string(spec.SubtestDownload), "set-write-deadline").Inc()
 		return err
 	}
 
@@ -73,13 +73,13 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 			if !ok { // This means that the measurer has terminated
 				closer.StartClosing(conn)
 				ndt7metrics.ClientSenderErrors.WithLabelValues(
-					proto, string(spec.SubtestDownload), "measurer-closed")
+					proto, string(spec.SubtestDownload), "measurer-closed").Inc()
 				return nil
 			}
 			if err := conn.WriteJSON(m); err != nil {
 				logging.Logger.WithError(err).Warn("sender: conn.WriteJSON failed")
 				ndt7metrics.ClientSenderErrors.WithLabelValues(
-					proto, string(spec.SubtestDownload), "write-json")
+					proto, string(spec.SubtestDownload), "write-json").Inc()
 				return err
 			}
 			// Only save measurements sent to the client.
@@ -87,7 +87,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 			if err := ping.SendTicks(conn, deadline); err != nil {
 				logging.Logger.WithError(err).Warn("sender: ping.SendTicks failed")
 				ndt7metrics.ClientSenderErrors.WithLabelValues(
-					proto, string(spec.SubtestDownload), "ping-send-ticks")
+					proto, string(spec.SubtestDownload), "ping-send-ticks").Inc()
 				return err
 			}
 		default:
@@ -95,7 +95,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 				logging.Logger.WithError(err).Warn(
 					"sender: conn.WritePreparedMessage failed")
 				ndt7metrics.ClientSenderErrors.WithLabelValues(
-					proto, string(spec.SubtestDownload), "write-prepared-message")
+					proto, string(spec.SubtestDownload), "write-prepared-message").Inc()
 				return err
 			}
 			// The following block of code implements the scaling of message size
@@ -117,7 +117,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 			if err != nil {
 				logging.Logger.WithError(err).Warn("sender: makePreparedMessage failed")
 				ndt7metrics.ClientSenderErrors.WithLabelValues(
-					proto, string(spec.SubtestDownload), "make-prepared-message")
+					proto, string(spec.SubtestDownload), "make-prepared-message").Inc()
 				return err
 			}
 		}

--- a/ndt7/receiver/receiver.go
+++ b/ndt7/receiver/receiver.go
@@ -36,7 +36,7 @@ func start(
 	if err != nil {
 		logging.Logger.WithError(err).Warn("receiver: conn.SetReadDeadline failed")
 		ndt7metrics.ClientReceiverErrors.WithLabelValues(
-			proto, string(kind), "set-read-deadline")
+			proto, string(kind), "set-read-deadline").Inc()
 		return
 	}
 	conn.SetPongHandler(func(s string) error {
@@ -46,7 +46,7 @@ func start(
 			logging.Logger.Debugf("receiver: ApplicationLevel RTT: %d ms", rtt)
 		} else {
 			ndt7metrics.ClientReceiverErrors.WithLabelValues(
-				proto, string(kind), "ping-parse-ticks")
+				proto, string(kind), "ping-parse-ticks").Inc()
 		}
 		return err
 	})
@@ -54,7 +54,7 @@ func start(
 		mtype, mdata, err := conn.ReadMessage()
 		if err != nil {
 			ndt7metrics.ClientReceiverErrors.WithLabelValues(
-				proto, string(kind), "read-message")
+				proto, string(kind), "read-message").Inc()
 			return
 		}
 		if mtype != websocket.TextMessage {
@@ -62,7 +62,7 @@ func start(
 			case downloadReceiver:
 				logging.Logger.Warn("receiver: got non-Text message")
 				ndt7metrics.ClientReceiverErrors.WithLabelValues(
-					proto, string(kind), "wrong-message-type")
+					proto, string(kind), "wrong-message-type").Inc()
 				return // Unexpected message type
 			default:
 				// NOTE: this is the bulk upload path. In this case, the mdata is not used.
@@ -74,13 +74,13 @@ func start(
 		if err != nil {
 			logging.Logger.WithError(err).Warn("receiver: json.Unmarshal failed")
 			ndt7metrics.ClientReceiverErrors.WithLabelValues(
-				proto, string(kind), "unmarshal-client-message")
+				proto, string(kind), "unmarshal-client-message").Inc()
 			return
 		}
 		data.ClientMeasurements = append(data.ClientMeasurements, measurement)
 	}
 	ndt7metrics.ClientReceiverErrors.WithLabelValues(
-		proto, string(kind), "receiver-context-expired")
+		proto, string(kind), "receiver-context-expired").Inc()
 }
 
 // StartDownloadReceiverAsync starts the receiver in a background goroutine and

--- a/ndt7/upload/sender/sender.go
+++ b/ndt7/upload/sender/sender.go
@@ -37,7 +37,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 	if err != nil {
 		logging.Logger.WithError(err).Warn("sender: conn.SetWriteDeadline failed")
 		ndt7metrics.ClientSenderErrors.WithLabelValues(
-			proto, string(spec.SubtestUpload), "set-write-deadline")
+			proto, string(spec.SubtestUpload), "set-write-deadline").Inc()
 		return err
 	}
 
@@ -51,13 +51,13 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 		if !ok { // This means that the previous step has terminated
 			closer.StartClosing(conn)
 			ndt7metrics.ClientSenderErrors.WithLabelValues(
-				proto, string(spec.SubtestUpload), "measurer-closed")
+				proto, string(spec.SubtestUpload), "measurer-closed").Inc()
 			return nil
 		}
 		if err := conn.WriteJSON(m); err != nil {
 			logging.Logger.WithError(err).Warn("sender: conn.WriteJSON failed")
 			ndt7metrics.ClientSenderErrors.WithLabelValues(
-				proto, string(spec.SubtestUpload), "write-json")
+				proto, string(spec.SubtestUpload), "write-json").Inc()
 			return err
 		}
 		// Only save measurements sent to the client.
@@ -65,7 +65,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 		if err := ping.SendTicks(conn, deadline); err != nil {
 			logging.Logger.WithError(err).Warn("sender: ping.SendTicks failed")
 			ndt7metrics.ClientSenderErrors.WithLabelValues(
-				proto, string(spec.SubtestUpload), "ping-send-ticks")
+				proto, string(spec.SubtestUpload), "ping-send-ticks").Inc()
 			return err
 		}
 	}


### PR DESCRIPTION
This change fixes the accidental omission of `.Inc()` on the sender and receiver error metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/301)
<!-- Reviewable:end -->
