### PR TITLE
Add consistent ndt5 protocol metric labels

### DIFF
--- a/ndt5/c2s/c2s.go
+++ b/ndt5/c2s/c2s.go
@@ -48,7 +48,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 	record = &ArchivalData{}
 
 	m := controlConn.Messager()
-	connType := s.ConnectionType().String()
+	connType := s.ConnectionType().Label()
 
 	srv, err := s.SingleServingServer("c2s")
 	if err != nil {

--- a/ndt5/meta/meta.go
+++ b/ndt5/meta/meta.go
@@ -26,7 +26,7 @@ func ManageTest(ctx context.Context, m protocol.Messager, s ndt.Server) ([]metad
 	var err error
 	var message []byte
 	results := []metadata.NameValue{}
-	connType := s.ConnectionType().String()
+	connType := s.ConnectionType().Label()
 
 	err = m.SendMessage(protocol.TestPrepare, []byte{})
 	if err != nil {

--- a/ndt5/ndt/server.go
+++ b/ndt5/ndt/server.go
@@ -10,8 +10,23 @@ import (
 // websockets, or secure websockets.
 type ConnectionType string
 
+// String returns the connection type named used in archival data.
 func (c ConnectionType) String() string {
 	return string(c)
+}
+
+// Label returns the connection type name used in monitoring metrics.
+func (c ConnectionType) Label() string {
+	switch c {
+	case WSS:
+		return "ndt5+wss"
+	case WS:
+		return "ndt5+ws"
+	case Plain:
+		return "ndt5+plain"
+	default:
+		return "ndt5+unknown"
+	}
 }
 
 // The types of connections we support.

--- a/ndt5/s2c/s2c.go
+++ b/ndt5/s2c/s2c.go
@@ -56,7 +56,7 @@ func ManageTest(ctx context.Context, controlConn protocol.Connection, s ndt.Serv
 		}
 	}()
 
-	connType := s.ConnectionType().String()
+	connType := s.ConnectionType().Label()
 
 	srv, err := s.SingleServingServer("s2c")
 	if err != nil {


### PR DESCRIPTION
This change makes prometheus metric labels consistent between ndt5 and ndt7 metrics without changing archival data. This makes it much easier to interpret dashboards that combine metrics from both NDT5 and NDT7 because they will begin using the same label names.

This change updates the "protocol" label for all ndt5 metrics to use the same label string used by the "TestRate" histogram metric.

Specifically:

* "WSS"  becomes "ndt5+wss"
* "WS" becomes "ndt5+ws"
* "PLAIN" becomes "ndt5+plain"

Because the `ConnectionType` protocol is part of the NDT5 archived result, this change preserves the current `String()` format of the `ConnectionType`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/306)
<!-- Reviewable:end -->
