### PR TITLE
Update error log

### DIFF
--- a/ndt5/ndt5.go
+++ b/ndt5/ndt5.go
@@ -58,7 +58,7 @@ func SaveData(record *data.NDT5Result, datadir string) {
 	enc := json.NewEncoder(file)
 	err = enc.Encode(record)
 	if err != nil {
-		log.Println("Could not encode", record, "to", file.Name())
+		log.Println("ERROR: Could not encode", record, "to", file.Name(), "err:", err)
 		return
 	}
 	log.Println("Wrote", file.Name())


### PR DESCRIPTION
This change adds the error message to the log message when the JSON encoder fails to encode a result.

This is an strange situation because the result struct does not have complex types, so it's unclear what is causing it to fail. Part of https://github.com/m-lab/ndt-server/issues/307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/308)
<!-- Reviewable:end -->
