### PR TITLE
fix(docker-compose.yml): make sure it works on macOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,19 @@ services:
     cap_drop:
       - ALL
     ports:
-      - "443:4443"
+      - target: 4443
+        published: 4443
+        protocol: tcp
+        mode: bridge
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: bridge
     command: [
       "./ndt-server",
       "-cert", "/certs/cert.pem",
       "-key", "/certs/key.pem",
       "-datadir", "/datadir",
-      "-ndt7_addr", ":4443"
+      "-ndt7_addr", ":4443",
+      "-ndt7_addr_cleartext", ":8080"
     ]


### PR DESCRIPTION
I am not super happy about exposing 80 and 443 because that would break
running docker-compose on a host that enforces privileged ports.

The fixes in this diff are such that I can run the instructions provided
in the README.md and access ndt7 endpoints.

Sadly, I have no way of testing this on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/318)
<!-- Reviewable:end -->
