### PR TITLE
Allow path labels for ndt5 and ndt7 resources

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -144,6 +144,7 @@ func main() {
 	ndt5WsMux := http.NewServeMux()
 	ndt5WsMux.Handle("/", http.FileServer(http.Dir(*htmlDir)))
 	ndt5WsMux.Handle("/ndt_protocol", ndt5handler.NewWS(*dataDir+"/ndt5"))
+	controller.AllowPathLabel("/ndt_protocol")
 	ndt5WsServer := httpServer(
 		*ndt5WsAddr,
 		// NOTE: do not use `ac.Then()` to prevent 'double jeopardy' for
@@ -164,6 +165,8 @@ func main() {
 	}
 	ndt7Mux.Handle(spec.DownloadURLPath, http.HandlerFunc(ndt7Handler.Download))
 	ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))
+	controller.AllowPathLabel(spec.DownloadURLPath)
+	controller.AllowPathLabel(spec.UploadURLPath)
 	ndt7ServerCleartext := httpServer(
 		*ndt7AddrCleartext,
 		ac7.Then(logging.MakeAccessLogHandler(ndt7Mux)),


### PR DESCRIPTION
This change uses the function added in https://github.com/m-lab/access/pull/29 to allow access token metric labels to include the paths for ndt5 and ndt7 resources. This change will prevent random requests by bots from filling the `path=` label of the `controller_access_token_requests_total` metric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/324)
<!-- Reviewable:end -->
