### PR TITLE
Added GO111MODULE=auto on build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ versionflags="-X github.com/m-lab/ndt-server/version.Version=$VERSION"
 
 COMMIT=$(git log -1 --format=%h)
 versionflags="${versionflags} -X github.com/m-lab/go/prometheusx.GitShortCommit=${COMMIT}"
+
+go env -w GO111MODULE=auto
 go get -v -t                                                           \
     -tags netgo                                                        \
     -ldflags "$versionflags -extldflags \"-static\""                   \


### PR DESCRIPTION
In my machine : 
```
Linux whitebomb 5.4.0-70-generic #78-Ubuntu SMP Fri Mar 19 13:29:52 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
```
when i tried to run docker containers, I had this error:
``` bash
+ go get -v -t -tags netgo -ldflags '-X github.com/m-lab/ndt-server/version.Version=v0.20.5-1-gc89a459 -X github.com/m-lab/go/prometheusx.GitShortCommit=c89a459 -extldflags "-static"' .
go: cannot find main module, but found .git/config in /go/src/github.com/m-lab/ndt-server
	to create a module there, run:
	go mod init
ERROR: Service 'ndt-server' failed to build: The command '/bin/sh -c /go/src/github.com/m-lab/ndt-server/build.sh' returned a non-zero code: 1
```
I solved adding  GO111MODULE=auto on build.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/330)
<!-- Reviewable:end -->
