### PR TITLE
ndt7: fix message scaling in the download measurement

### DIFF
--- a/ndt7/download/sender/sender.go
+++ b/ndt7/download/sender/sender.go
@@ -3,6 +3,7 @@ package sender
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -106,6 +107,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 			// scale deployments of this algorithm anyway, so there's no point
 			// in engaging in fine grained calibration before knowing.
 			totalSent += int64(bulkMessageSize)
+			fmt.Printf("bulkMessageSize: %d, totalSent: %d\n", int64(bulkMessageSize), totalSent)
 			if int64(bulkMessageSize) >= spec.MaxScaledMessageSize {
 				continue // No further scaling is required
 			}

--- a/ndt7/download/sender/sender.go
+++ b/ndt7/download/sender/sender.go
@@ -106,7 +106,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 			// scale deployments of this algorithm anyway, so there's no point
 			// in engaging in fine grained calibration before knowing.
 			totalSent += int64(bulkMessageSize)
-			if totalSent >= spec.MaxScaledMessageSize {
+			if int64(bulkMessageSize) >= spec.MaxScaledMessageSize {
 				continue // No further scaling is required
 			}
 			if int64(bulkMessageSize) > totalSent/spec.ScalingFraction {

--- a/ndt7/download/sender/sender.go
+++ b/ndt7/download/sender/sender.go
@@ -3,7 +3,6 @@ package sender
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -107,7 +106,6 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) 
 			// scale deployments of this algorithm anyway, so there's no point
 			// in engaging in fine grained calibration before knowing.
 			totalSent += int64(bulkMessageSize)
-			fmt.Printf("bulkMessageSize: %d, totalSent: %d\n", int64(bulkMessageSize), totalSent)
 			if int64(bulkMessageSize) >= spec.MaxScaledMessageSize {
 				continue // No further scaling is required
 			}

--- a/ndt7/spec/spec.go
+++ b/ndt7/spec/spec.go
@@ -20,7 +20,7 @@ const MaxMessageSize = 1 << 24
 // MaxScaledMessageSize is the maximum value of a scaled binary WebSocket
 // message size. This should be <= of MaxMessageSize. The 1<<20 value is
 // a good compromise between Go and JavaScript as seen in cloud based tests.
-const MaxScaledMessageSize = 1 << 23
+const MaxScaledMessageSize = 1 << 20
 
 // DefaultWebsocketBufferSize is the read and write buffer sizes used when
 // creating a websocket connection. This size is independent of the websocket

--- a/ndt7/spec/spec.go
+++ b/ndt7/spec/spec.go
@@ -20,7 +20,7 @@ const MaxMessageSize = 1 << 24
 // MaxScaledMessageSize is the maximum value of a scaled binary WebSocket
 // message size. This should be <= of MaxMessageSize. The 1<<20 value is
 // a good compromise between Go and JavaScript as seen in cloud based tests.
-const MaxScaledMessageSize = 1 << 20
+const MaxScaledMessageSize = 1 << 23
 
 // DefaultWebsocketBufferSize is the read and write buffer sizes used when
 // creating a websocket connection. This size is independent of the websocket


### PR DESCRIPTION
The message scaling algorithm stopped at ~64k even if `MaxScaledMessageSize` is set to 1MB (`1 << 20`).

This one-line diff fixes the algorithm by comparing the current message size (rather than the total amount of bytes sent) to the maximum message size.

As a result, the first doubling happens after 16 messages and the subsequent ones every 8 messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/331)
<!-- Reviewable:end -->
