### PR TITLE
Update Dockerfile to pin Go and Alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:alpine as ndt-server-build
+FROM golang:1.16.7-alpine3.14 as ndt-server-build
 RUN apk add --no-cache git gcc linux-headers musl-dev
 ADD . /go/src/github.com/m-lab/ndt-server
 RUN /go/src/github.com/m-lab/ndt-server/build.sh
 
 # Now copy the built image into the minimal base image
-FROM alpine
+FROM alpine:3.14
 COPY --from=ndt-server-build /go/bin/ndt-server /
 ADD ./html /html
 WORKDIR /

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:alpine as ndt-server-build
+FROM golang:1.16.7-alpine3.14 as ndt-server-build
 RUN apk add --no-cache git gcc linux-headers musl-dev openssl bash
 
 ADD . /go/src/github.com/m-lab/ndt-server

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -13,7 +13,7 @@
 # A base image for building and the final image.
 # NOTE: use debian based golang image to easily access libraries and development
 # packages that are unavailable or harder to setup in alpine-based images.
-FROM golang:1.16.7-buster as ndt-server-build
+FROM golang:1.16.7-buster as ndtbase
 WORKDIR /
 RUN apt-get update && apt-get install -y git libmaxminddb0 libevent-2.1-6 \
     libevent-core-2.1-6 libevent-extra-2.1-6 \

--- a/TestDockerfile
+++ b/TestDockerfile
@@ -13,7 +13,7 @@
 # A base image for building and the final image.
 # NOTE: use debian based golang image to easily access libraries and development
 # packages that are unavailable or harder to setup in alpine-based images.
-FROM golang:1.13-buster AS ndtbase
+FROM golang:1.16.7-buster as ndt-server-build
 WORKDIR /
 RUN apt-get update && apt-get install -y git libmaxminddb0 libevent-2.1-6 \
     libevent-core-2.1-6 libevent-extra-2.1-6 \


### PR DESCRIPTION
This PR pins the Go version used in the build container to 1.16 (the same version as the currently ongoing canary) and also the Alpine version for both containers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/339)
<!-- Reviewable:end -->

Closes #338.