### PR TITLE
Update traceroute-caller invocation in start.sh

### DIFF
--- a/fullstack/start.sh
+++ b/fullstack/start.sh
@@ -55,7 +55,8 @@ mkdir -p "${DATA_DIR}"/traceroute
 /traceroute-caller \
   --prometheusx.listen-address=:9992 \
   --uuid-prefix-file="${UUID_FILE}" \
-  --outputPath="${DATA_DIR}"/traceroute \
+  --hopannotation-output="${DATA_DIR}"/hopannotation1 \
+  --traceroute-output="${DATA_DIR}"/scamper1 \
   --tcpinfo.eventsocket=/var/local/tcpeventsocket.sock \
   &
 


### PR DESCRIPTION
This updates the invocation of traceroute-caller in the fullstack Docker image.
The `--outputPath` command-line argument has been replaced by `--traceroute-output`  and `--hopannotation-output`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/342)
<!-- Reviewable:end -->
