### PR TITLE
Use a Reader in receiver.go to prevent unnecessary memory alloc

### DIFF
--- a/ndt7/receiver/receiver.go
+++ b/ndt7/receiver/receiver.go
@@ -57,7 +57,7 @@ func start(
 		mtype, r, err := conn.NextReader()
 		if err != nil {
 			ndt7metrics.ClientReceiverErrors.WithLabelValues(
-				proto, string(kind), "read-message").Inc()
+				proto, string(kind), "read-message-type").Inc()
 			return
 		}
 		if mtype != websocket.TextMessage {

--- a/ndt7/receiver/receiver.go
+++ b/ndt7/receiver/receiver.go
@@ -5,6 +5,7 @@ package receiver
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -51,7 +52,9 @@ func start(
 		return err
 	})
 	for receiverctx.Err() == nil { // Liveness!
-		mtype, mdata, err := conn.ReadMessage()
+		// By getting a Reader here we avoid allocating memory for the message
+		// when the message type is not websocket.TextMessage.
+		mtype, r, err := conn.NextReader()
 		if err != nil {
 			ndt7metrics.ClientReceiverErrors.WithLabelValues(
 				proto, string(kind), "read-message").Inc()
@@ -68,6 +71,13 @@ func start(
 				// NOTE: this is the bulk upload path. In this case, the mdata is not used.
 				continue // No further processing required
 			}
+		}
+		// This is a TextMessage, so we must read it.
+		mdata, err := ioutil.ReadAll(r)
+		if err != nil {
+			ndt7metrics.ClientReceiverErrors.WithLabelValues(
+				proto, string(kind), "read-message").Inc()
+			return
 		}
 		var measurement model.Measurement
 		err = json.Unmarshal(mdata, &measurement)


### PR DESCRIPTION
This change is very similar to https://github.com/m-lab/ndt7-client-go/pull/63 - instead of using `conn.ReadMessage()` which allocates memory for the message, we get an `io.Reader`, check the message type and don't process it further if the type is not `websocket.TextMessage`.

Even if this is usually not a problem on M-Lab production hardware, this patch allowed me to measure a 1 Gb/s link fully with a ODROID XU-4 (armv7, 32 bit) running ndt-server, reducing the CPU usage from ~250% to ~120%

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/343)
<!-- Reviewable:end -->
