### PR TITLE
Move NDT5 ServerMetadata to avoid panic

### DIFF
--- a/ndt5/ndt5.go
+++ b/ndt5/ndt5.go
@@ -131,8 +131,9 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) 
 		Version:        version.Version,
 		StartTime:      time.Now(),
 		Control: &control.ArchivalData{
-			UUID:     conn.UUID(),
-			Protocol: s.ConnectionType(),
+			UUID:           conn.UUID(),
+			Protocol:       s.ConnectionType(),
+			ServerMetadata: s.Metadata(),
 		},
 		ServerIP:   sIP,
 		ServerPort: sPort,
@@ -226,7 +227,6 @@ func handleControlChannel(conn protocol.Connection, s ndt.Server, isMon string) 
 		record.Control.ClientMetadata, err = meta.ManageTest(ctx, m, s)
 		rtx.PanicOnError(err, "META - Could not run meta test (uuid: %s)", record.Control.UUID)
 	}
-	record.Control.ServerMetadata = s.Metadata()
 	speedMsg := fmt.Sprintf("You uploaded at %.4f and downloaded at %.4f", c2sRate*1000, s2cRate*1000)
 	log.Println(speedMsg)
 	// For historical reasons, clients expect results in kbps


### PR DESCRIPTION
A portion of NDT5 tests panic, causing the `ServerMetadata` field not to be populated (~10%).

Example:
[Log](https://pantheon.corp.google.com/logs/query;query=%22ndt-4dkmn_1642699102_000000000029FF3C%22;timeRange=2022-02-28T15:00:00.000Z%2F2022-02-28T17:00:00.000Z;cursorTimestamp=2022-02-28T16:02:04.825169258Z?project=mlab-oti) from [panic](https://github.com/m-lab/ndt-server/blob/10d0acf0a86a3c82a00687e85e48c6cb506eb297/ndt5/ndt5.go#L223).
![Screenshot 2022-03-01 2 02 41 PM](https://user-images.githubusercontent.com/21001496/156232200-cf89fdef-8a87-4739-918d-c643ff3a5dc7.png)

Resulting `ServerMetadata`.
![Screenshot 2022-03-01 2 01 50 PM](https://user-images.githubusercontent.com/21001496/156232220-4effb45d-16e2-47e6-8f82-05683c857e4c.png)

This PR is moving the initialization of `ServerMetadata` so it happens before the panics.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/353)
<!-- Reviewable:end -->
