### PR TITLE
Fix race condition in fullstack start.sh

### DIFF
--- a/fullstack/Dockerfile
+++ b/fullstack/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=measurementlab/tcp-info /licences/zstd/ /licences/zstd/
 # easily from the image, due to C-linking issues and the differences between
 # alpine and ubuntu, so just rebuild it here.
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y libpcap-dev golang-go git
+RUN apt-get update && apt-get install -y libpcap-dev golang-go git socat
 RUN go get github.com/m-lab/packet-headers
 RUN mv /root/go/bin/packet-headers /packet-headers
 

--- a/fullstack/start.sh
+++ b/fullstack/start.sh
@@ -46,7 +46,8 @@ mkdir -p "${DATA_DIR}"/tcpinfo
   --tcpinfo.eventsocket=/var/local/tcpeventsocket.sock \
   &
 
-while [[ ! -e /var/local/tcpeventsocket.sock ]]; do
+echo "Waiting for the tcpinfo eventsocket to become available..."
+while ! socat -u OPEN:/dev/null UNIX-CONNECT:/var/local/tcpeventsocket.sock; do
   sleep 1
 done
 


### PR DESCRIPTION
The script previously just verified that the socket file existed. The file is created by tcp-info ~immediately, but connecting to it returns a "connection refused" error for the first few milliseconds.

Instead of just checking for the socket's existence, we attempt to actually connect to it with socat before starting traceroute-caller and packet-headers.

Closes #215 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/355)
<!-- Reviewable:end -->
