### PR TITLE
RFC: Add user-specified parameters for transfer byte limits

### DIFF
--- a/html/ndt7-upload.js
+++ b/html/ndt7-upload.js
@@ -14,7 +14,8 @@ onmessage = function (ev) {
     let now = performance.now()
     const duration = 10000  // millisecond
     const every = 250  // millisecond
-    if (now - start > duration) {
+    // Run for duration or until server closes connection.
+    if (now - start > duration || sock.readyState == sock.CLOSED) {
       sock.close()
       return
     }

--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -24,8 +24,10 @@
 </head>
 <body>
   <div>
-    <div id='download' class='result row'>[Download]</div>
-    <div id='upload' class='result row'>[Upload]</div>
+    <div id='downloadShort' class='result row'>[Download (short)]</div>
+    <div id='downloadLong' class='result row'>[Download (long)]</div>
+    <div id='uploadShort' class='result row'>[Upload (short)]</div>
+    <div id='uploadLong' class='result row'>[Upload (long)]</div>
   </div>
   <script type='text/javascript'>
     /* jshint esversion: 6, asi: true */
@@ -48,8 +50,8 @@
       })
     }
 
-    function runSomething(testName, callback) {
-      ndt7core.run(location.href, testName, function(ev, val) {
+    function runSomething(url, testName, suffix, callback) {
+      ndt7core.run(url, testName, function(ev, val) {
         console.log(ev, val)
         if (ev === 'complete') {
           if (callback !== undefined) {
@@ -59,20 +61,35 @@
         }
         if (ev === 'measurement' && val.AppInfo !== undefined &&
             val.Origin === 'client') {
-          updateView(testName, val.AppInfo)
+          updateView(testName+suffix, val.AppInfo)
         }
       })
     }
 
     function runDownload(callback) {
-      runSomething('download', callback)
+      runSomething(location.href, 'download', 'Short', callback);
     }
 
     function runUpload(callback) {
-      runSomething('upload', callback)
+      runSomething(location.href, 'upload', 'Short', callback);
     }
 
-    runDownload(function() { runUpload(); })
+    function runLongUpload() {
+      const regex = /param_/g; // make parameters unrecognizable to server.
+      runSomething(location.href.replace(regex, ''), 'upload', 'Long');
+    }
+    function runLongDownload(callback) {
+      const regex = /param_/g; // make parameters unrecognizable to server.
+      runSomething(location.href.replace(regex, ''), 'download', 'Long', callback);
+    }
+
+    runDownload(function() {
+      runLongDownload(function() {
+        runUpload(function() {
+          runLongUpload();
+        });
+      });
+    })
   </script>
 </body>
 </html>

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -81,8 +81,7 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	ndt7metrics.ClientConnections.WithLabelValues(string(kind), "result").Inc()
 
 	// Collect most client metadata from request parameters.
-	p := appendClientMetadata(data, req.URL.Query())
-	data.Parameters = p
+	appendClientMetadata(data, req.URL.Query())
 	data.ServerMetadata = h.ServerMetadata
 	// Create ultimate result.
 	result := setupResult(conn)
@@ -217,7 +216,7 @@ var paramKeyRe = regexp.MustCompile("^param_")
 
 // appendClientMetadata adds |values| to the archival client metadata contained
 // in the request parameter values. Some select key patterns will be excluded.
-func appendClientMetadata(data *model.ArchivalData, values url.Values) *model.Parameters {
+func appendClientMetadata(data *model.ArchivalData, values url.Values) {
 	var p *model.Parameters
 	for name, values := range values {
 		if matches := excludeKeyRe.MatchString(name); matches {
@@ -233,7 +232,7 @@ func appendClientMetadata(data *model.ArchivalData, values url.Values) *model.Pa
 				Value: values[0], // NOTE: this will ignore multi-value parameters.
 			})
 	}
-	return p
+	data.Parameters = p
 }
 
 func updateParameters(p *model.Parameters, name, value string) *model.Parameters {

--- a/ndt7/model/archivaldata.go
+++ b/ndt7/model/archivaldata.go
@@ -13,6 +13,7 @@ type ArchivalData struct {
 	UUID               string
 	StartTime          time.Time
 	EndTime            time.Time
+	Parameters         *Parameters `json:",omitempty"`
 	ServerMeasurements []Measurement
 	ClientMeasurements []Measurement
 	ClientMetadata     []metadata.NameValue `json:",omitempty"`
@@ -57,4 +58,12 @@ type BBRInfo struct {
 type TCPInfo struct {
 	tcp.LinuxTCPInfo
 	ElapsedTime int64
+}
+
+// Parameters contain fields that may alter the default behavior of an ndt7
+// measurement.
+type Parameters struct {
+	CloseAfterDownloadBytesAcked  int64
+	CloseAfterUploadBytesReceived int64
+	CubicDownload                 bool
 }


### PR DESCRIPTION
This change is a prototype that would add user parameters to NDT7 measurements and archival results. The current implementation is not ready to merge in its current form. This is an RFC.

The current implementation supports the following parameters:

* `param_close_after_download_bytes_acked` - the server will close the websocket conn after observing tcpinfo.BytesAcked greater than the given value.
* `param_close_after_upload_bytes_received` - the server will close the websocket conn after observing tcpinfo.BytesReceived greater than the given value.
* `param_cubic_download` - parsed but not enableable. Included as an illustration of how we could enable this or other options in the future.

In the first two cases, the measurement/observation events depend on the `measurer` memoryless [sample frequency][memoryless] - meaning that the time between actually reaching the `BytesAcked` or `BytesReceived` threshold (kernel state) and observing that (ndt-server) could be up to [MaxPoissonSamplingInterval](https://github.com/m-lab/ndt-server/blob/master/ndt7/spec/spec.go#L50) (625ms). So, there is a fundamental imprecision around when the server observes and closes the connection; there is no guarantee about how much data is actually transferred, only that it is *at least* the amount requested.

Currently, the parameter value is in bytes and unconstrained. Ideally, we would limit these values to a fixed set of thresholds, e.g. 1, 2.5, 5, 10, etc..

[memoryless]: https://github.com/m-lab/ndt-server/blob/master/ndt7/measurer/measurer.go#L79-L82

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/360)
<!-- Reviewable:end -->
