### PR TITLE
Force conn.Close() after MaxRuntime in handler.go

### DIFF
--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -106,11 +106,11 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	var rate float64
 	if kind == spec.SubtestDownload {
 		result.Download = data
-		err = download.Do(req.Context(), conn, data)
+		err = download.Do(ctx, conn, data)
 		rate = downRate(data.ServerMeasurements)
 	} else if kind == spec.SubtestUpload {
 		result.Upload = data
-		err = upload.Do(req.Context(), conn, data)
+		err = upload.Do(ctx, conn, data)
 		rate = upRate(data.ServerMeasurements)
 	}
 

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -74,7 +74,8 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	// that under particular network conditions the connection can remain open
 	// while the receiver goroutine is blocked on a read syscall, long after
 	// the client is gone. This is a workaround for that.
-	ctx, _ := context.WithTimeout(req.Context(), spec.MaxRuntime)
+	ctx, cancel := context.WithTimeout(req.Context(), spec.MaxRuntime)
+	defer cancel()
 	go func() {
 		<-ctx.Done()
 		warnonerror.Close(conn, "runMeasurement: ignoring conn.Close result")

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -77,7 +77,7 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	ctx, _ := context.WithTimeout(req.Context(), spec.MaxRuntime)
 	go func() {
 		<-ctx.Done()
-		warnonerror.Close(conn, "runMeasurement: ignoring conn.Close result, connection timed out")
+		warnonerror.Close(conn, "runMeasurement: ignoring conn.Close result")
 	}()
 	// Create measurement archival data.
 	data, err := getData(conn)


### PR DESCRIPTION
Related to #361. I'll add some more information about the issue there.

This PR changes how `conn.Close()` is called at the end of a measurement. Even if the current code _looks_ correct, we have seen many instances where the receiver and sender goroutines are stuck reading from / writing to the socket for a very long time after the end of a measurement. The deferred Close() in handler.go is supposed to force-close the connection when the receiver returns, but since the receiver is stuck trying to read from the socket this deferred function actually never gets called. Instead of using a deferred function, we start a separate goroutine that waits on a context timeout (or manual cancellation, when everything goes well and the sender goroutine cancels the context).

Assuming this approach looks fine to you, I would deploy this change on a small subset of servers and verify that no connections longer than 15s are recorded on these. The volume of connections exhibiting this issue is currently high enough that a couple of days should suffice to confirm. Unfortunately, I was not able to replicate it locally as it does never seem to happen under "normal" network conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/362)
<!-- Reviewable:end -->
