### PR TITLE
Add metric to count whether enabling BBR succeeded

### DIFF
--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -7,12 +7,24 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/m-lab/go/memoryless"
 	"github.com/m-lab/ndt-server/logging"
 	"github.com/m-lab/ndt-server/ndt7/model"
 	"github.com/m-lab/ndt-server/ndt7/spec"
 	"github.com/m-lab/ndt-server/netx"
+)
+
+var (
+	BBREnabled = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "netx_bbr_enabled",
+			Help: "A counter of every attempt to enable bbr.",
+		},
+		[]string{"status"},
+	)
 )
 
 // Measurer performs measurements
@@ -33,10 +45,13 @@ func New(conn *websocket.Conn, UUID string) *Measurer {
 func (m *Measurer) getSocketAndPossiblyEnableBBR() (netx.ConnInfo, error) {
 	ci := netx.ToConnInfo(m.conn.UnderlyingConn())
 	err := ci.EnableBBR()
+	success := "true"
 	if err != nil {
+		success = "false"
 		logging.Logger.WithError(err).Warn("Cannot enable BBR")
 		// FALLTHROUGH
 	}
+	BBREnabled.WithLabelValues(success).Inc()
 	return ci, nil
 }
 

--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -20,7 +20,7 @@ import (
 var (
 	BBREnabled = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "netx_bbr_enabled",
+			Name: "ndt7_measurer_bbr_enabled",
 			Help: "A counter of every attempt to enable bbr.",
 		},
 		[]string{"status"},


### PR DESCRIPTION
One of the requirements identified in the To the Cloud milestone requires a means of determining whether the BBR module is loaded and available for NDT7 measurements.

This change adds a new prometheus counter metric to track the rate of successful bbr enabled events.

If a node was misconfigured (e.g. bbr module not loaded), then the failure rate would be > 0 while the success rate was == 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/363)
<!-- Reviewable:end -->
