### PR TITLE
Lowering max message size in upload worker

### DIFF
--- a/html/ndt7-upload.js
+++ b/html/ndt7-upload.js
@@ -18,7 +18,7 @@ onmessage = function (ev) {
       sock.close()
       return
     }
-    const maxMessageSize = 16777216 /* = (1<<24) = 16MB */
+    const maxMessageSize = 8388608 /* = (1<<2) = 8MB */
     if (data.length < maxMessageSize && data.length < (total - sock.bufferedAmount)/16) {
       data = new Uint8Array(data.length * 2) // TODO(bassosimone): fill this message
     }

--- a/html/ndt7-upload.js
+++ b/html/ndt7-upload.js
@@ -18,7 +18,7 @@ onmessage = function (ev) {
       sock.close()
       return
     }
-    const maxMessageSize = 8388608 /* = (1<<2) = 8MB */
+    const maxMessageSize = 8388608 /* = (1<<23) = 8MB */
     if (data.length < maxMessageSize && data.length < (total - sock.bufferedAmount)/16) {
       data = new Uint8Array(data.length * 2) // TODO(bassosimone): fill this message
     }


### PR DESCRIPTION
We've discovered, that while using the embedded js client to run ndt7 tests, the upload speeds are very low for the connections at higher speeds (we were testing it with 4G and 10G). The reason is that the WebSocket connection is closed at the begging of the tests. The connection is closed by the server because its buffer is overflowing. This happens on the following browsers: Chrome, Edge, and Safari. Firefox is completing the upload test normally for the same set-up.

As a fix for this issue, we're proposing lowering the maxMessageSize on the upload worker on the JS client from 16MB to 8MB. This is also a value used in the other JS client: [ndt7-js](https://github.com/m-lab/ndt7-js). This client could also replace the current one, if it's OK with you I could add it as a part of this PR. I see that there is a [PR](https://github.com/m-lab/ndt-server/pull/291) that introduces that client, but it is over 2 years old and there were some changes in the other repository recently.

Another way to stop the upload test from failing is to slightly increase MaxMessageSize on the server side, which is set to 16MB. Changing it to 18MB is enough for our testing.

It would help us greatly in using NDT if you could include this change or resolve this issue.

Thank you very much in advance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/365)
<!-- Reviewable:end -->
