### PR TITLE
Name counter metric with correct _total suffix

### DIFF
--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -20,7 +20,7 @@ import (
 var (
 	BBREnabled = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ndt7_measurer_bbr_enabled",
+			Name: "ndt7_measurer_bbr_enabled_total",
 			Help: "A counter of every attempt to enable bbr.",
 		},
 		[]string{"status"},


### PR DESCRIPTION
Counter metrics should have a suffix with `_total`. I accidentally forgot this when originally adding this counter in https://github.com/m-lab/ndt-server/pull/363. This change corrects the metric name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/366)
<!-- Reviewable:end -->
