### PR TITLE
Added parameter for changing server side max messasge size for the NDT upload test

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ docker run --network=bridge                \
            -key /certs/key.pem             \
            -datadir /datadir               \
            -ndt7_addr :4443                \
-           -ndt7_addr_cleartext :8080
+           -ndt7_addr_cleartext :8080      \
+           -ndt7_max_msg_size 16777216
 ```
 
 ### Alternate setup & running (Windows & MacOS)

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -35,6 +35,7 @@ var (
 	// Flags that can be passed in on the command line
 	ndt7Addr          = flag.String("ndt7_addr", ":443", "The address and port to use for the ndt7 test")
 	ndt7AddrCleartext = flag.String("ndt7_addr_cleartext", ":80", "The address and port to use for the ndt7 cleartext test")
+	ndt7MaxMsgSize    = flag.Int64("ndt7_max_msg_size", 16777216, "The maximum value of upload message size")
 	ndt5Addr          = flag.String("ndt5_addr", ":3001", "The address and port to use for the unencrypted ndt5 test")
 	ndt5WsAddr        = flag.String("ndt5_ws_addr", "127.0.0.1:3002", "The address and port to use for the ndt5 WS test")
 	ndt5WssAddr       = flag.String("ndt5_wss_addr", ":3010", "The address and port to use for the ndt5 WSS test")
@@ -208,6 +209,7 @@ func main() {
 		SecurePort:     *ndt7Addr,
 		InsecurePort:   *ndt7AddrCleartext,
 		ServerMetadata: serverMetadata,
+		MaxMsgSize:     *ndt7MaxMsgSize,
 	}
 	ndt7Mux.Handle(spec.DownloadURLPath, http.HandlerFunc(ndt7Handler.Download))
 	ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -2,7 +2,6 @@
 package handler
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -39,6 +38,8 @@ type Handler struct {
 	InsecurePort string
 	// ServerMetadata contains deployment-specific metadata.
 	ServerMetadata []metadata.NameValue
+	//
+	MaxMsgSize int64
 }
 
 // warnAndClose emits message as a warning and the sends a Bad Request
@@ -69,17 +70,7 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 		ndt7metrics.ClientConnections.WithLabelValues(string(kind), "websocket-error").Inc()
 		return
 	}
-	// Make sure that the connection is closed after (at most) MaxRuntime.
-	// Download and upload tests have their own timeouts, but we have observed
-	// that under particular network conditions the connection can remain open
-	// while the receiver goroutine is blocked on a read syscall, long after
-	// the client is gone. This is a workaround for that.
-	ctx, cancel := context.WithTimeout(req.Context(), spec.MaxRuntime)
-	defer cancel()
-	go func() {
-		<-ctx.Done()
-		warnonerror.Close(conn, "runMeasurement: ignoring conn.Close result")
-	}()
+	defer warnonerror.Close(conn, "runMeasurement: ignoring conn.Close result")
 	// Create measurement archival data.
 	data, err := getData(conn)
 	if err != nil {
@@ -107,11 +98,11 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	var rate float64
 	if kind == spec.SubtestDownload {
 		result.Download = data
-		err = download.Do(ctx, conn, data)
+		err = download.Do(req.Context(), conn, data)
 		rate = downRate(data.ServerMeasurements)
 	} else if kind == spec.SubtestUpload {
 		result.Upload = data
-		err = upload.Do(ctx, conn, data)
+		err = upload.Do(req.Context(), conn, data, h.MaxMsgSize)
 		rate = upRate(data.ServerMeasurements)
 	}
 

--- a/ndt7/upload/upload.go
+++ b/ndt7/upload/upload.go
@@ -14,13 +14,13 @@ import (
 // the subtest. The conn argument is the open WebSocket connection. The data
 // argument is the archival data where results are saved. All arguments are
 // owned by the caller of this function.
-func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData) error {
+func Do(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData, MaxMsgSize int64) error {
 	// Implementation note: use child contexts so the sender is strictly time
 	// bounded. After timeout, the sender closes the conn, which results in the
 	// receiver completing.
 
 	// Receive and save client-provided measurements in data.
-	recv := receiver.StartUploadReceiverAsync(ctx, conn, data)
+	recv := receiver.StartUploadReceiverAsync(ctx, conn, data, MaxMsgSize)
 
 	// Perform upload and save server-measurements in data.
 	// TODO: move sender.Start logic to this file.


### PR DESCRIPTION
We've added this change to allow changing the max accepted message size for the upload test on the server side. This property might be influencing the recorded performance so we think that this might be a good addition.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/367)
<!-- Reviewable:end -->
