### PR TITLE
Remove bigquery ignore tag for ConnectionInfo

### DIFF
--- a/ndt7/model/archivaldata.go
+++ b/ndt7/model/archivaldata.go
@@ -24,7 +24,7 @@ type ArchivalData struct {
 // structure is specified in the ndt7 specification.
 type Measurement struct {
 	AppInfo        *AppInfo        `json:",omitempty"`
-	ConnectionInfo *ConnectionInfo `json:",omitempty" bigquery:"-"`
+	ConnectionInfo *ConnectionInfo `json:",omitempty"`
 	BBRInfo        *BBRInfo        `json:",omitempty"`
 	TCPInfo        *TCPInfo        `json:",omitempty"`
 }


### PR DESCRIPTION
This PR removes the `bigquery:"-"` tag from the `ConnectionInfo` field.

Because this optional field was to be ignored by BQ, it caused a fatal error in the Gardener in an instance where it was included in the `json` file and BQ did not recognize the field.

```
20220806:ndt/ndt7 Load {Location: "gs://etl-mlab-oti/ndt/ndt7/2022/08/06/20220806T040510.251033Z-ndt7-mlab2-gru02-ndt.tgz.json"; Message: "Error while reading data, error message: JSON parsing error in row starting at position 951624: No such field: raw.Download.ClientMeasurements.ConnectionInfo. File: gs://etl-mlab-oti/ndt/ndt7/2022/08/06/20220806T040510.251033Z-ndt7-mlab2-gru02-ndt.tgz.json"; Reason: "invalid"}
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/368)
<!-- Reviewable:end -->
