### PR TITLE
Replace calls to Fd() with syscall.RawConn.Control()

### DIFF
--- a/bbr/bbr_linux.go
+++ b/bbr/bbr_linux.go
@@ -15,24 +15,36 @@ import (
 )
 
 func enableBBR(fp *os.File) error {
-	// Note: Fd() returns uintptr but on Unix we can safely use int for sockets.
-	return syscall.SetsockoptString(int(fp.Fd()), syscall.IPPROTO_TCP,
-		syscall.TCP_CONGESTION, "bbr")
+	rawconn, err := fp.SyscallConn()
+	if err != nil {
+		return err
+	}
+	rawconn.Control(func(fd uintptr) {
+		// Note: Fd() returns uintptr but on Unix we can safely use int for sockets.
+		err = syscall.SetsockoptString(int(fd), syscall.IPPROTO_TCP, syscall.TCP_CONGESTION, "bbr")
+	})
+	return err
 }
 
 func getMaxBandwidthAndMinRTT(fp *os.File) (inetdiag.BBRInfo, error) {
 	cci := C.union_tcp_cc_info{}
 	size := uint32(C.sizeof_union_tcp_cc_info)
-	// Note: Fd() returns uintptr but on Unix we can safely use int for sockets.
-	_, _, err := syscall.Syscall6(
-		uintptr(syscall.SYS_GETSOCKOPT),
-		uintptr(int(fp.Fd())),
-		uintptr(C.IPPROTO_TCP),
-		uintptr(C.TCP_CC_INFO),
-		uintptr(unsafe.Pointer(&cci)),
-		uintptr(unsafe.Pointer(&size)),
-		uintptr(0))
 	metrics := inetdiag.BBRInfo{}
+	rawconn, rawConnErr := fp.SyscallConn()
+	if rawConnErr != nil {
+		return metrics, rawConnErr
+	}
+	var err syscall.Errno
+	rawconn.Control(func(fd uintptr) {
+		_, _, err = syscall.Syscall6(
+			uintptr(syscall.SYS_GETSOCKOPT),
+			fd,
+			uintptr(C.IPPROTO_TCP),
+			uintptr(C.TCP_CC_INFO),
+			uintptr(unsafe.Pointer(&cci)),
+			uintptr(unsafe.Pointer(&size)),
+			uintptr(0))
+	})
 	if err != 0 {
 		// C.get_bbr_info returns ENOSYS when the system does not support BBR. In
 		// such case let us map the error to ErrNoSupport, such that this Linux

--- a/tcpinfox/tcpinfox_linux.go
+++ b/tcpinfox/tcpinfox_linux.go
@@ -9,17 +9,23 @@ import (
 )
 
 func getTCPInfo(fp *os.File) (*tcp.LinuxTCPInfo, error) {
-	// Note: Fd() returns uintptr but on Unix we can safely use int for sockets.
 	tcpInfo := tcp.LinuxTCPInfo{}
 	tcpInfoLen := uint32(unsafe.Sizeof(tcpInfo))
-	_, _, err := syscall.Syscall6(
-		uintptr(syscall.SYS_GETSOCKOPT),
-		uintptr(int(fp.Fd())),
-		uintptr(syscall.SOL_TCP),
-		uintptr(syscall.TCP_INFO),
-		uintptr(unsafe.Pointer(&tcpInfo)),
-		uintptr(unsafe.Pointer(&tcpInfoLen)),
-		uintptr(0))
+	rawConn, rawConnErr := fp.SyscallConn()
+	if rawConnErr != nil {
+		return &tcpInfo, rawConnErr
+	}
+	var err syscall.Errno
+	rawConn.Control(func(fd uintptr) {
+		_, _, err = syscall.Syscall6(
+			uintptr(syscall.SYS_GETSOCKOPT),
+			fd,
+			uintptr(syscall.SOL_TCP),
+			uintptr(syscall.TCP_INFO),
+			uintptr(unsafe.Pointer(&tcpInfo)),
+			uintptr(unsafe.Pointer(&tcpInfoLen)),
+			uintptr(0))
+	})
 	if err != 0 {
 		return &tcpInfo, err
 	}


### PR DESCRIPTION
`Fd()` removes the `O_NONBLOCK` flag from the descriptor before returning it.

From [os/file_unix.go](https://github.com/golang/go/blob/master/src/os/file_unix.go#L85):
```
	// If we put the file descriptor into nonblocking mode,
	// then set it to blocking mode before we return it,
	// because historically we have always returned a descriptor
	// opened in blocking mode. The File will continue to work,
	// but any blocking operation will tie up a thread.
```

When `Fd()` is called on a `*os.File` obtained via `conn.File()`, this descriptor is actually a duplicate but the underlying socket is shared. The end result is that the original `conn` still thinks it has a non-blocking socket, while the socket actually became blocking. This causes things like `conn.Close()` blocking forever if no data is received.

This should actually resolve #361 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/371)
<!-- Reviewable:end -->
