### PR TITLE
Add error string label to bbr enabled metric

### DIFF
--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -23,7 +23,7 @@ var (
 			Name: "ndt7_measurer_bbr_enabled_total",
 			Help: "A counter of every attempt to enable bbr.",
 		},
-		[]string{"status"},
+		[]string{"status", "error"},
 	)
 )
 
@@ -46,12 +46,15 @@ func (m *Measurer) getSocketAndPossiblyEnableBBR() (netx.ConnInfo, error) {
 	ci := netx.ToConnInfo(m.conn.UnderlyingConn())
 	err := ci.EnableBBR()
 	success := "true"
+	errstr := ""
 	if err != nil {
 		success = "false"
-		logging.Logger.WithError(err).Warn("Cannot enable BBR")
+		errstr = err.Error()
+		uuid, _ := ci.GetUUID() // to log error with uuid.
+		logging.Logger.WithError(err).Warn("Cannot enable BBR: " + uuid)
 		// FALLTHROUGH
 	}
-	BBREnabled.WithLabelValues(success).Inc()
+	BBREnabled.WithLabelValues(success, errstr).Inc()
 	return ci, nil
 }
 


### PR DESCRIPTION
We have learned that in practice, we see many `status=false` due to "bad file descriptor" errors. Unfortunately, this is not the error case we were originally interested in for the `ndt7_measurer_bbr_enabled_total`. 

To be able to identify failures enabling BBR due to the module not being present, this change adds the error string to the metric labels. We are looking for the error `"no such file or directory"`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/373)
<!-- Reviewable:end -->
