### PR TITLE
Disable Debug level logging

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -18,7 +18,7 @@ import (
 // when dockerising an Apache or Nginx instance.
 var Logger = log.Logger{
 	Handler: json.New(os.Stderr),
-	Level:   log.DebugLevel,
+	Level:   log.InfoLevel,
 }
 
 // MakeAccessLogHandler wraps |handler| with another handler that logs


### PR DESCRIPTION
The ndt-server generates debug level logging and this is operationally costly for log retention, collection and provides negligible benefit for production deployments.

Ultimately, this setting should be configurable. Until then, this change makes the default log level `InfoLevel`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/374)
<!-- Reviewable:end -->
