### PR TITLE
Update to golang 1.18

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 FROM golang:1.18 as ndt-server-build
-RUN apk add --no-cache git gcc linux-headers musl-dev openssl bash
+RUN apt-get update && apt-get install -y openssl bash
 
 ADD . /go/src/github.com/m-lab/ndt-server
 ADD ./html /html

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,6 +1,4 @@
 FROM golang:1.18 as ndt-server-build
-RUN apt-get update && apt-get install -y openssl bash
-
 ADD . /go/src/github.com/m-lab/ndt-server
 ADD ./html /html
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.16.7-alpine3.14 as ndt-server-build
+FROM golang:1.18-alpine3.14 as ndt-server-build
 RUN apk add --no-cache git gcc linux-headers musl-dev openssl bash
 
 ADD . /go/src/github.com/m-lab/ndt-server

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.14 as ndt-server-build
+FROM golang:1.18 as ndt-server-build
 RUN apk add --no-cache git gcc linux-headers musl-dev openssl bash
 
 ADD . /go/src/github.com/m-lab/ndt-server


### PR DESCRIPTION
This change updates the Dockerfile.local to use go1.18.

This is part of https://github.com/m-lab/dev-tracker/issues/735

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/375)
<!-- Reviewable:end -->
