### PR TITLE
Add /health endpoint for ndt-server

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -159,7 +159,7 @@ func setLameDuck(status float64) {
 }
 
 // Handle requests to the /health endpoint.
-// Return a '200' status code only if the server is not in lame duck mode.
+// Writes out a 200 status code only if the server is not in lame duck mode.
 func handleHealth(rw http.ResponseWriter, req *http.Request) {
 	if isLameDuck {
 		rw.WriteHeader(http.StatusInternalServerError)

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -98,6 +98,7 @@ func catchSigterm() {
 	}
 }
 
+// Set internal lame duck status and metric.
 func setLameDuck(status float64) {
 	isLameDuck = status != 0
 	lameDuck.Set(status)
@@ -268,6 +269,7 @@ func main() {
 
 	// Set up handler for /health endpoint.
 	healthMux := http.NewServeMux()
+	// Return a '200' status code only if the server is not in lame duck.
 	healthMux.Handle("/health", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if isLameDuck {
 			rw.WriteHeader(http.StatusInternalServerError)

--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -382,3 +382,33 @@ func sortNameValueSlice(nv []metadata.NameValue) {
 		return nv[i].Name < nv[j].Name
 	})
 }
+
+func Test_handleHealth(t *testing.T) {
+	tests := []struct {
+		name     string
+		lameDuck bool
+		want     int
+	}{
+		{
+			name:     "not-lame-duck",
+			lameDuck: false,
+			want:     200,
+		},
+		{
+			name:     "lame-duck",
+			lameDuck: true,
+			want:     500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isLameDuck = tt.lameDuck
+			writer := httptest.NewRecorder()
+			handleHealth(writer, nil)
+
+			if writer.Code != tt.want {
+				t.Errorf("ndt-server.handleHealth() got = %d, want %d", writer.Code, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new `/health` endpoint for ndt-server, which writes out a 200 status code if the server is healthy (i.e., not in lame duck) and an error code otherwise.

This will be queried by the Heartbeat Service and incorporated into the local health assessment for the instance.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/376)
<!-- Reviewable:end -->
