### PR TITLE
Update README.md to Linux 4.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a [ndt5](
 https://github.com/ndt-project/ndt/wiki/NDTProtocol) and [ndt7](
 spec/ndt7-protocol.md) server written in Go. This code may compile under
 many systems, including macOS and Windows, but is specifically designed
-and tested for running on Linux 4.17+.
+and tested for running on Linux 4.19+.
 
 ## Clients
 


### PR DESCRIPTION
The [NDT7 protocol](https://github.com/m-lab/ndt-server/blob/main/spec/ndt7-protocol.md) mentions M-Lab uses Linux 4.19. Certain key `TCP_INFO` struct members are only available in Linux 4.19+ (notably [`bytes_sent`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ba113c3aa79a7f941ac162d05a3620bdc985c58d)), so for consistency update the `README.md` to say the same.

btw, the NDT7 protocol also says:

> An implementation running on
> a kernel where a specific `TCP_INFO` variable mentioned in this specification
> is missing SHOULD NOT include such variable in the `TCPInfo` object sent to
> the client.

but that is not what this implementation does, it sends a full `TCPInfo` object where missing variables have `0` value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/382)
<!-- Reviewable:end -->
