### PR TITLE
Add -compress-results flag to optionally disable compressing results

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -44,6 +44,7 @@ var (
 	tlsVersion        = flag.String("tls.version", "", "Minimum TLS version. Valid values: 1.2 or 1.3")
 	dataDir           = flag.String("datadir", "/var/spool/ndt", "The directory in which to write data files")
 	htmlDir           = flag.String("htmldir", "html", "The directory from which to serve static web content.")
+	compress          = flag.Bool("compress-results", true, "Whether to compress result files")
 	deploymentLabels  = flagx.KeyValue{}
 	tokenVerifyKey    = flagx.FileBytesArray{}
 	tokenRequired5    bool
@@ -236,10 +237,11 @@ func main() {
 	ndt7Mux := http.NewServeMux()
 	ndt7Mux.Handle("/", http.FileServer(http.Dir(*htmlDir)))
 	ndt7Handler := &handler.Handler{
-		DataDir:        *dataDir,
-		SecurePort:     *ndt7Addr,
-		InsecurePort:   *ndt7AddrCleartext,
-		ServerMetadata: serverMetadata,
+		DataDir:         *dataDir,
+		SecurePort:      *ndt7Addr,
+		InsecurePort:    *ndt7AddrCleartext,
+		ServerMetadata:  serverMetadata,
+		CompressResults: *compress,
 	}
 	ndt7Mux.Handle(spec.DownloadURLPath, http.HandlerFunc(ndt7Handler.Download))
 	ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -39,6 +39,8 @@ type Handler struct {
 	InsecurePort string
 	// ServerMetadata contains deployment-specific metadata.
 	ServerMetadata []metadata.NameValue
+	// CompressResults controls whether the result files saved by the server are compressed.
+	CompressResults bool
 }
 
 // warnAndClose emits message as a warning and the sends a Bad Request
@@ -176,7 +178,7 @@ func setupResult(conn *websocket.Conn) *data.NDT7Result {
 }
 
 func (h Handler) writeResult(uuid string, kind spec.SubtestKind, result *data.NDT7Result) {
-	fp, err := results.NewFile(uuid, h.DataDir, kind)
+	fp, err := results.NewFile(uuid, h.DataDir, kind, h.CompressResults)
 	if err != nil {
 		logging.Logger.WithError(err).Warn("results.NewFile failed")
 		return

--- a/ndt7/results/file.go
+++ b/ndt7/results/file.go
@@ -3,6 +3,7 @@ package results
 import (
 	"compress/gzip"
 	"encoding/json"
+	"io"
 	"os"
 	"path"
 	"time"
@@ -13,31 +14,43 @@ import (
 
 // File is the file where we save measurements.
 type File struct {
-	// Writer is the gzip writer instance
-	Writer *gzip.Writer
+	// Writer is the writer for results.
+	Writer io.Writer
 
-	// Fp is the underlying file
-	Fp *os.File
-
-	// UUID is the UUID of this subtest
+	// UUID is the UUID of this subtest.
 	UUID string
+
+	// fp is the underlying writer file.
+	fp *os.File
+
+	// gzip is an optional writer for compressed results.
+	gzip *gzip.Writer
 }
 
 // newFile opens a measurements file in the current working
 // directory on success and returns an error on failure.
-func newFile(datadir, what, uuid string) (*File, error) {
+func newFile(datadir, what, uuid string, compress bool) (*File, error) {
 	timestamp := time.Now().UTC()
 	dir := path.Join(datadir, "ndt7", timestamp.Format("2006/01/02"))
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return nil, err
 	}
-	name := dir + "/ndt7-" + what + "-" + timestamp.Format("20060102T150405.000000000Z") + "." + uuid + ".json.gz"
+	name := dir + "/ndt7-" + what + "-" + timestamp.Format("20060102T150405.000000000Z") + "." + uuid + ".json"
+	if compress {
+		name += ".gz"
+	}
 	// My assumption here is that we have nanosecond precision and hence it's
 	// unlikely to have conflicts. If I'm wrong, O_EXCL will let us know.
 	fp, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
 	if err != nil {
 		return nil, err
+	}
+	if !compress {
+		return &File{
+			Writer: fp,
+			fp:     fp,
+		}, nil
 	}
 	writer, err := gzip.NewWriterLevel(fp, gzip.BestSpeed)
 	if err != nil {
@@ -46,7 +59,8 @@ func newFile(datadir, what, uuid string) (*File, error) {
 	}
 	return &File{
 		Writer: writer,
-		Fp:     fp,
+		fp:     fp,
+		gzip:   writer,
 	}, nil
 }
 
@@ -55,8 +69,8 @@ func newFile(datadir, what, uuid string) (*File, error) {
 // failure. The "datadir" argument specifies the directory on disk to write the
 // data into and the what argument should indicate whether this is a
 // spec.SubtestDownload or a spec.SubtestUpload ndt7 measurement.
-func NewFile(uuid string, datadir string, what spec.SubtestKind) (*File, error) {
-	fp, err := newFile(datadir, string(what), uuid)
+func NewFile(uuid string, datadir string, what spec.SubtestKind, compress bool) (*File, error) {
+	fp, err := newFile(datadir, string(what), uuid, compress)
 	if err != nil {
 		logging.Logger.WithError(err).Warn("newFile failed")
 		return nil, err
@@ -66,12 +80,14 @@ func NewFile(uuid string, datadir string, what spec.SubtestKind) (*File, error) 
 
 // Close closes the measurement file.
 func (fp *File) Close() error {
-	err := fp.Writer.Close()
-	if err != nil {
-		fp.Fp.Close()
-		return err
+	if fp.gzip != nil {
+		err := fp.gzip.Close()
+		if err != nil {
+			fp.fp.Close()
+			return err
+		}
 	}
-	return fp.Fp.Close()
+	return fp.fp.Close()
 }
 
 // WriteResult serializes |result| as JSON.


### PR DESCRIPTION
This change adds a new flag (preserving prior default behavior) to enable or disable compressing ndt7 result files.

After this change, the ndt-server can use `-compress-results=false` to disable gzip compressed result files, making them jostler/autoloader compatible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/383)
<!-- Reviewable:end -->
