### PR TITLE
Bind the health check service to localhost

### DIFF
--- a/ndt-server.go
+++ b/ndt-server.go
@@ -38,7 +38,7 @@ var (
 	ndt5Addr          = flag.String("ndt5_addr", ":3001", "The address and port to use for the unencrypted ndt5 test")
 	ndt5WsAddr        = flag.String("ndt5_ws_addr", "127.0.0.1:3002", "The address and port to use for the ndt5 WS test")
 	ndt5WssAddr       = flag.String("ndt5_wss_addr", ":3010", "The address and port to use for the ndt5 WSS test")
-	healthAddr        = flag.String("health_addr", "localhost:8000", "The address and port to use for health checks")
+	healthAddr        = flag.String("health_addr", "127.0.0.1:8000", "The address and port to use for health checks")
 	certFile          = flag.String("cert", "", "The file with server certificates in PEM format.")
 	keyFile           = flag.String("key", "", "The file with server key in PEM format.")
 	tlsVersion        = flag.String("tls.version", "", "Minimum TLS version. Valid values: 1.2 or 1.3")

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -38,7 +38,7 @@ var (
 	ndt5Addr          = flag.String("ndt5_addr", ":3001", "The address and port to use for the unencrypted ndt5 test")
 	ndt5WsAddr        = flag.String("ndt5_ws_addr", "127.0.0.1:3002", "The address and port to use for the ndt5 WS test")
 	ndt5WssAddr       = flag.String("ndt5_wss_addr", ":3010", "The address and port to use for the ndt5 WSS test")
-	healthAddr        = flag.String("health_addr", ":8000", "The address and port to use for health checks")
+	healthAddr        = flag.String("health_addr", "localhost:8000", "The address and port to use for health checks")
 	certFile          = flag.String("cert", "", "The file with server certificates in PEM format.")
 	keyFile           = flag.String("key", "", "The file with server key in PEM format.")
 	tlsVersion        = flag.String("tls.version", "", "Minimum TLS version. Valid values: 1.2 or 1.3")


### PR DESCRIPTION
This change updates the default `-health_addr` to explicitly bind to localhost:8000 to prevent accidentally exposing this service to the public internet. This change should have not effect since the heartbeat service already [targets localhost unconditionally](https://github.com/m-lab/locate/blob/main/cmd/heartbeat/health/endpoint-check.go#L10)

Part of:
* https://github.com/m-lab/ops-tracker/issues/1798

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/391)
<!-- Reviewable:end -->
