### PR TITLE
Add optional eventsocket Server to ndt-server

### DIFF
--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -49,13 +49,11 @@ func countFiles(dir string) int {
 	return count
 }
 
-func setupMain() func() {
+func setupMain(t *testing.T) func() {
 	cleanups := []func(){}
 
 	// Create self-signed certs in a temp directory.
-	dir, err := os.MkdirTemp("", "TestNdtServerMain")
-	rtx.Must(err, "Could not create tempdir")
-
+	dir := t.TempDir()
 	certFile := "cert.pem"
 	keyFile := "key.pem"
 
@@ -104,7 +102,7 @@ func (ft *fakeT) Error(args ...interface{}) {
 
 func Test_ContextCancelsMain(t *testing.T) {
 	// Set up certs and the environment vars for the commandline.
-	cleanup := setupMain()
+	cleanup := setupMain(t)
 	defer cleanup()
 
 	// Set up the global context for main()
@@ -131,7 +129,7 @@ func Test_MainIntegrationTest(t *testing.T) {
 		t.Skip("Integration tests take too long")
 	}
 	// Set up certs and the environment vars for the commandline.
-	cleanup := setupMain()
+	cleanup := setupMain(t)
 	defer cleanup()
 
 	// Set up the global context for main()

--- a/ndt-server_test.go
+++ b/ndt-server_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -54,7 +53,7 @@ func setupMain() func() {
 	cleanups := []func(){}
 
 	// Create self-signed certs in a temp directory.
-	dir, err := ioutil.TempDir("", "TestNdtServerMain")
+	dir, err := os.MkdirTemp("", "TestNdtServerMain")
 	rtx.Must(err, "Could not create tempdir")
 
 	certFile := "cert.pem"

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -59,18 +59,18 @@ func warnAndClose(writer http.ResponseWriter, message string) {
 }
 
 // Download handles the download subtest.
-func (h Handler) Download(rw http.ResponseWriter, req *http.Request) {
+func (h *Handler) Download(rw http.ResponseWriter, req *http.Request) {
 	h.runMeasurement(spec.SubtestDownload, rw, req)
 }
 
 // Upload handles the upload subtest.
-func (h Handler) Upload(rw http.ResponseWriter, req *http.Request) {
+func (h *Handler) Upload(rw http.ResponseWriter, req *http.Request) {
 	h.runMeasurement(spec.SubtestUpload, rw, req)
 }
 
 // runMeasurement conditionally runs either download or upload based on kind.
 // The kind argument must be spec.SubtestDownload or spec.SubtestUpload.
-func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, req *http.Request) {
+func (h *Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, req *http.Request) {
 	// Validate client request before opening the connection.
 	params, err := validateEarlyExit(req.URL.Query())
 	if err != nil {

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -30,6 +30,8 @@ import (
 	"github.com/m-lab/ndt-server/ndt7/upload"
 	"github.com/m-lab/ndt-server/netx"
 	"github.com/m-lab/ndt-server/version"
+	"github.com/m-lab/tcp-info/eventsocket"
+	"github.com/m-lab/tcp-info/inetdiag"
 )
 
 // Handler handles ndt7 subtests.
@@ -44,6 +46,8 @@ type Handler struct {
 	ServerMetadata []metadata.NameValue
 	// CompressResults controls whether the result files saved by the server are compressed.
 	CompressResults bool
+	// Events is the server for reporting new connections.
+	Events eventsocket.Server
 }
 
 // warnAndClose emits message as a warning and the sends a Bad Request
@@ -106,13 +110,15 @@ func (h Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, r
 	appendClientMetadata(data, req.URL.Query())
 	data.ServerMetadata = h.ServerMetadata
 	// Create ultimate result.
-	result := setupResult(conn)
+	result, id := setupResult(conn)
 	result.StartTime = time.Now().UTC()
+	h.Events.FlowCreated(result.StartTime, data.UUID, id)
 
-	// Guarantee results are written even if function panics.
+	// Guarantee results are written even if test functions panics.
 	defer func() {
 		result.EndTime = time.Now().UTC()
 		h.writeResult(data.UUID, kind, result)
+		h.Events.FlowDeleted(result.EndTime, data.UUID)
 	}()
 
 	// Run measurement.
@@ -165,7 +171,7 @@ func setupConn(writer http.ResponseWriter, request *http.Request) *websocket.Con
 }
 
 // setupResult creates an NDT7Result from the given conn.
-func setupResult(conn *websocket.Conn) *data.NDT7Result {
+func setupResult(conn *websocket.Conn) (*data.NDT7Result, inetdiag.SockID) {
 	// NOTE: unless we plan to run the NDT server over different protocols than TCP,
 	// then we expect RemoteAddr and LocalAddr to always return net.TCPAddr types.
 	clientAddr := netx.ToTCPAddr(conn.RemoteAddr())
@@ -184,7 +190,14 @@ func setupResult(conn *websocket.Conn) *data.NDT7Result {
 		ServerIP:       serverAddr.IP.String(),
 		ServerPort:     serverAddr.Port,
 	}
-	return result
+	id := inetdiag.SockID{
+		SrcIP:  result.ServerIP,
+		DstIP:  result.ClientIP,
+		SPort:  uint16(result.ServerPort),
+		DPort:  uint16(result.ClientPort),
+		Cookie: -1, // Note: we do not populate the socket cookie here.
+	}
+	return result, id
 }
 
 func (h Handler) writeResult(uuid string, kind spec.SubtestKind, result *data.NDT7Result) {
@@ -260,7 +273,7 @@ func validateEarlyExit(values url.Values) (*sender.Params, error) {
 
 		value := values[0]
 		if !slices.Contains(spec.ValidEarlyExitValues, value) {
-			return nil, fmt.Errorf("Invalid %s parameter value %s", name, value)
+			return nil, fmt.Errorf("invalid %s parameter value %s", name, value)
 		}
 
 		// Convert string to int64.

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -114,7 +114,7 @@ func (h *Handler) runMeasurement(kind spec.SubtestKind, rw http.ResponseWriter, 
 	result.StartTime = time.Now().UTC()
 	h.Events.FlowCreated(result.StartTime, data.UUID, id)
 
-	// Guarantee results are written even if test functions panics.
+	// Guarantee results are written even if subtest functions panic.
 	defer func() {
 		result.EndTime = time.Now().UTC()
 		h.writeResult(data.UUID, kind, result)

--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -46,7 +46,7 @@ type Handler struct {
 	ServerMetadata []metadata.NameValue
 	// CompressResults controls whether the result files saved by the server are compressed.
 	CompressResults bool
-	// Events is the server for reporting new connections.
+	// Events is for reporting new connections to the event server.
 	Events eventsocket.Server
 }
 

--- a/ndt7/handler/handler_integration_test.go
+++ b/ndt7/handler/handler_integration_test.go
@@ -1,0 +1,84 @@
+// Package handler implements the WebSocket handler for ndt7.
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/ndt-server/ndt7/ndt7test"
+	"github.com/m-lab/ndt-server/ndt7/spec"
+	"github.com/m-lab/tcp-info/inetdiag"
+)
+
+// fakeServer implements the eventsocket.Server interface for testing the ndt7 handler.
+type fakeServer struct {
+	created int
+	deleted int
+}
+
+func (f *fakeServer) Listen() error               { return nil }
+func (f *fakeServer) Serve(context.Context) error { return nil }
+func (f *fakeServer) FlowCreated(timestamp time.Time, uuid string, sockid inetdiag.SockID) {
+	f.created++
+}
+func (f *fakeServer) FlowDeleted(timestamp time.Time, uuid string) {
+	f.deleted++
+}
+
+func TestHandler_Download(t *testing.T) {
+	t.Run("download flow events", func(t *testing.T) {
+		fs := &fakeServer{}
+		ndt7h, srv := ndt7test.NewNDT7Server(t)
+		defer srv.Close()
+		ndt7h.Events = fs
+		conn, err := simpleConnect(srv.URL)
+		testingx.Must(t, err, "failed to dial websocket ndt7 test")
+		err = downloadHelper(context.Background(), t, conn)
+		if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			testingx.Must(t, err, "failed to download")
+		}
+		// Wait briefly for connection close event.
+		time.Sleep(time.Second)
+
+		// Both events should occur once.
+		if fs.created == 0 {
+			t.Errorf("flow events created not detected; got %d, want 1", fs.created)
+		}
+		if fs.deleted == 0 {
+			t.Errorf("flow events deleted not detected; got %d, want 1", fs.deleted)
+		}
+	})
+}
+
+func simpleConnect(srv string) (*websocket.Conn, error) {
+	// Prepare to run a simplified download with ndt7test server.
+	URL, _ := url.Parse(srv)
+	URL.Scheme = "ws"
+	URL.Path = spec.DownloadURLPath
+	headers := http.Header{}
+	headers.Add("Sec-WebSocket-Protocol", spec.SecWebSocketProtocol)
+	headers.Add("User-Agent", "fake-user-agent")
+	ctx := context.Background()
+	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	conn, _, err := dialer.DialContext(ctx, URL.String(), headers)
+	return conn, err
+}
+
+// WARNING: this is not a reference client.
+func downloadHelper(ctx context.Context, t *testing.T, conn *websocket.Conn) error {
+	defer conn.Close()
+	conn.SetReadLimit(spec.MaxMessageSize)
+	err := conn.SetReadDeadline(time.Now().Add(spec.MaxRuntime))
+	testingx.Must(t, err, "failed to set read deadline")
+	_, _, err = conn.ReadMessage()
+	if err != nil {
+		return err
+	}
+	// We only read one message, so this is an early close.
+	return conn.Close()
+}

--- a/ndt7/handler/handler_integration_test.go
+++ b/ndt7/handler/handler_integration_test.go
@@ -35,7 +35,10 @@ func TestHandler_Download(t *testing.T) {
 		fs := &fakeServer{}
 		ndt7h, srv := ndt7test.NewNDT7Server(t)
 		defer srv.Close()
+		// Override the handler Events server with our fake server.
 		ndt7h.Events = fs
+
+		// Run a pseudo test to generate connection events.
 		conn, err := simpleConnect(srv.URL)
 		testingx.Must(t, err, "failed to dial websocket ndt7 test")
 		err = downloadHelper(context.Background(), t, conn)
@@ -45,7 +48,7 @@ func TestHandler_Download(t *testing.T) {
 		// Wait briefly for connection close event.
 		time.Sleep(time.Second)
 
-		// Both events should occur once.
+		// Verify that both events have occurred once.
 		if fs.created == 0 {
 			t.Errorf("flow events created not detected; got %d, want 1", fs.created)
 		}

--- a/ndt7/ndt7test/ndt7test.go
+++ b/ndt7/ndt7test/ndt7test.go
@@ -2,7 +2,6 @@ package ndt7test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -18,9 +17,7 @@ import (
 // NewNDT7Server creates a local httptest server capable of running an ndt7
 // measurement in unittests.
 func NewNDT7Server(t *testing.T) (*handler.Handler, *httptest.Server) {
-	dir, err := ioutil.TempDir("", "ndt7test-*")
-	testingx.Must(t, err, "failed to create temp dir")
-
+	dir := t.TempDir()
 	// TODO: add support for token verifiers.
 	// TODO: add support for TLS server.
 	ndt7Handler := &handler.Handler{DataDir: dir, Events: eventsocket.NullServer()}

--- a/ndt7/ndt7test/ndt7test.go
+++ b/ndt7/ndt7test/ndt7test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/m-lab/ndt-server/ndt7/handler"
 	"github.com/m-lab/ndt-server/ndt7/spec"
 	"github.com/m-lab/ndt-server/netx"
+	"github.com/m-lab/tcp-info/eventsocket"
 )
 
 // NewNDT7Server creates a local httptest server capable of running an ndt7
@@ -22,7 +23,7 @@ func NewNDT7Server(t *testing.T) (*handler.Handler, *httptest.Server) {
 
 	// TODO: add support for token verifiers.
 	// TODO: add support for TLS server.
-	ndt7Handler := &handler.Handler{DataDir: dir}
+	ndt7Handler := &handler.Handler{DataDir: dir, Events: eventsocket.NullServer()}
 	ndt7Mux := http.NewServeMux()
 	ndt7Mux.Handle(spec.DownloadURLPath, http.HandlerFunc(ndt7Handler.Download))
 	ndt7Mux.Handle(spec.UploadURLPath, http.HandlerFunc(ndt7Handler.Upload))


### PR DESCRIPTION
This change adds an `eventsocket.Server` to the ndt-server for the ndt7 protocol.

With this change, the ndt-server could operate as a replacement for tcp-info's eventsocket for deployments that run with standard sidecar services (e.g. uuid-annotator, or others) but without needing tcp-info to be the event source. In this configuration, the ndt-server itself becomes the event source, limiting events to verified ndt7 measurements (rather than every TCP connection).

For this change to be possible, the ndt7 `handler.Handler` methods now use a pointer receiver so that the `Handler.Events` field can be reset after `ndt7test.NewNDT7Server` creates a server using the default `eventsocket.NullServer`. As well, we add a `handler_integration_test.go` to allow import of the existing `ndt7test` package, which sets up an ndt7 server for testing.

At the same time, I've removed use of the deprecated `"io/ioutil"` `TempDir` in favor of `t.TempDir()`.

Default server behavior is unchanged. This change adds a new flag to the ndt-server, `-tcpinfo.eventsocket string`. We reuse the existing eventsocket flag name, just as the sidecars do, to preserve the symmetry between the serving flag and the client flag names. Since we now have multiple event servers, ideally the `eventsocket` package would be moved to a generic location such as `m-lab/go/eventsocket` and imported by tcp-info and ndt-server, using a more general flag name in all cases and sidecars, e.g. `-server.eventsocket`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/396)
<!-- Reviewable:end -->
