### PR TITLE
Fix: deterministic check for FlowDeleted

### DIFF
--- a/ndt7/handler/handler_integration_test.go
+++ b/ndt7/handler/handler_integration_test.go
@@ -52,8 +52,8 @@ func TestHandler_Download(t *testing.T) {
 		}
 		// Since the connection handler goroutine shutdown is independent of the
 		// server and client connection shutdowns, wait for the fakeServer to
-		// receive the delete flow message up to 5 seconds.
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// receive the delete flow message up to 15 seconds.
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		select {
 		case <-ctx.Done():

--- a/ndt7/handler/handler_integration_test.go
+++ b/ndt7/handler/handler_integration_test.go
@@ -34,7 +34,6 @@ func TestHandler_Download(t *testing.T) {
 	t.Run("download flow events", func(t *testing.T) {
 		fs := &fakeServer{}
 		ndt7h, srv := ndt7test.NewNDT7Server(t)
-		defer srv.Close()
 		// Override the handler Events server with our fake server.
 		ndt7h.Events = fs
 
@@ -45,15 +44,11 @@ func TestHandler_Download(t *testing.T) {
 		if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
 			testingx.Must(t, err, "failed to download")
 		}
-		// Wait briefly for connection close event.
-		time.Sleep(time.Second)
+		srv.Close()
 
 		// Verify that both events have occurred once.
 		if fs.created == 0 {
 			t.Errorf("flow events created not detected; got %d, want 1", fs.created)
-		}
-		if fs.deleted == 0 {
-			t.Errorf("flow events deleted not detected; got %d, want 1", fs.deleted)
 		}
 	})
 }


### PR DESCRIPTION
The previous test implementation was flaky. This change uses a channel to signal that the `FlowDeleted` path has been reached.

While the `srv.Close()` will prevent new connections, and the `downloadHelper()` closes the client connection, there is still an independent handler goroutine that reaches the `FlowDeleted` path after a short delay. Rather than using a larger static delay, this change sets a maximum delay and waits for the `deleted` channel to close, allowing the test to stop as quickly as it's able to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/397)
<!-- Reviewable:end -->
