### PR TITLE
avoid mixed content breaking when using https

### DIFF
--- a/html/ndt7.html
+++ b/html/ndt7.html
@@ -38,7 +38,7 @@
           client_name: 'ndt-server-example',
         },
         server: location.host,
-        protocol: 'ws',
+	protocol: location.protocol === 'https:' ? 'wss' : 'ws',
       },
       {
         serverChosen: function (server) {


### PR DESCRIPTION
When using the default ndt7.html that's shipped here, you'll end up with non-functional wss (or https). This makes it protocol agnostic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/400)
<!-- Reviewable:end -->
