### PR TITLE
Don't double sizes for slow clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-lab/ndt-server
 
-go 1.20
+go 1.23
 
 require (
 	github.com/apex/log v1.9.0

--- a/ndt7/download/sender/sender.go
+++ b/ndt7/download/sender/sender.go
@@ -126,6 +126,12 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData, 
 			if int64(bulkMessageSize) > totalSent/spec.ScalingFraction {
 				continue // message size still too big compared to sent data
 			}
+			if l := len(data.ServerMeasurements); l > 0 &&
+				data.ServerMeasurements[l-1].BBRInfo != nil &&
+				// Units: (bytes * 1000ms/s) / (bytes/s) = ms, and is being compared with a ms duration.
+				2*int64(bulkMessageSize)*1000/data.ServerMeasurements[l-1].BBRInfo.BW > spec.MaxPoissonSamplingInterval.Milliseconds() {
+				continue // next message size is greater than the client can be expected to consume in the next sampling interval
+			}
 			bulkMessageSize *= 2
 			preparedMessage, err = makePreparedMessage(bulkMessageSize)
 			if err != nil {


### PR DESCRIPTION
As discussed in Slack:

@pboothe : So what we need is to not double if the most recent tcpinfo data suggests that doubling will cause the next message to be too big?

@robertodauria : basically, yes. I was imagining it could be based on the actual delay between the tcpinfo snapshot and when the corresponding write to the socket returns -- if a tcpinfo snapshot couldn't be delivered for >= MaxPoissonSamplingInterval stop doubling the message size, for example, but other solutions are definitely possible

...or: setting a cap every time a tcpinfo snapshot is taken based on the current rate, check against this cap in sender.go before doubling, and keep the cap updated with each subsequent tcpinfo snapshot

@pboothe : Depending on what thread the tcpinfo measurement happens in, that last one feels like the right solution.

Nice and simple. Every measurement provides a max rate. Don’t double if the measured max rate suggests that each message will take more than half a second. Once TCP is cruising, we should cruise as well.

...

@robertodauria : half a second, or MaxPoissonSamplingInterval (600ms currently IIRC)? 

👍 