### PR TITLE
fix: disable HTTP/2 to resolve WebSocket compatibility issues

### DIFF
--- a/TestDockerfile
+++ b/TestDockerfile
@@ -15,6 +15,9 @@
 # packages that are unavailable or harder to setup in alpine-based images.
 FROM golang:1.18-buster as ndtbase
 WORKDIR /
+RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    sed -i '/buster-updates/d' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y git libmaxminddb0 libevent-2.1-6 \
     libevent-core-2.1-6 libevent-extra-2.1-6 \
     libevent-openssl-2.1-6 libevent-pthreads-2.1-6

--- a/ndt-server.go
+++ b/ndt-server.go
@@ -130,7 +130,7 @@ func httpServer(addr string, handler http.Handler) *http.Server {
 		tlsconf.NextProtos = append(tlsconf.NextProtos, acme.ALPNProto)
 	}
 
-	return &http.Server{
+	server := &http.Server{
 		Addr:      addr,
 		Handler:   handler,
 		TLSConfig: tlsconf,
@@ -140,7 +140,12 @@ func httpServer(addr string, handler http.Handler) *http.Server {
 		// servers.
 		ReadTimeout:  time.Minute,
 		WriteTimeout: time.Minute,
+		// Disable HTTP/2 to fix WebSocket compatibility issues with gorilla/websocket
+		// which doesn't support RFC 8441 HTTP/2 Extended CONNECT for WebSockets
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}
+
+	return server
 }
 
 // parseDeploymentLabels() returns an array of key-value pairs of type


### PR DESCRIPTION
Unconditionally disable HTTP/2 in ndt-server to fix WebSocket connection failures in Firefox.

## Tested Platforms (ndt7-js)
- Windows 11 + Chrome (latest)
- Windows 11 + Firefox (latest) 
- Windows 11 + Edge (latest)
- macOS Sonoma + Chrome (latest)
- macOS Sonoma + Safari (latest)
- iPhone 14 + Safari 16
- iPhone 15 Pro + Safari 17
- Samsung Galaxy S24 + Chrome (Android 14)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/411)
<!-- Reviewable:end -->
