### PR TITLE
Skip Linux-specific c2s tests on non-Linux platforms

### DIFF
--- a/ndt5/c2s/c2s_test.go
+++ b/ndt5/c2s/c2s_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	 "runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -33,6 +34,9 @@ func MustMakeNetConnection(ctx context.Context) (protocol.MeasuredConnection, ne
 }
 
 func Test_DrainForeverButMeasureFor_NormalOperation(t *testing.T) {
+	 if runtime.GOOS != "linux" {
+        t.Skip("Skipping test: requires Linux TCP features")
+    }
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sConn, cConn := MustMakeNetConnection(ctx)
@@ -57,6 +61,9 @@ func Test_DrainForeverButMeasureFor_NormalOperation(t *testing.T) {
 }
 
 func Test_DrainForeverButMeasureFor_EarlyClientQuit(t *testing.T) {
+	 if runtime.GOOS != "linux" {
+        t.Skip("Skipping test: requires Linux TCP features")
+    }
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sConn, cConn := MustMakeNetConnection(ctx)
@@ -100,6 +107,9 @@ func MustMakeWsConnection(ctx context.Context) (protocol.MeasuredConnection, *we
 }
 
 func Test_DrainForeverButMeasureFor_CountsAllBytesNotJustWsGoodput(t *testing.T) {
+	  if runtime.GOOS != "linux" {
+        t.Skip("Skipping test: requires Linux TCP features")
+    }
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sConn, cConn := MustMakeWsConnection(ctx)


### PR DESCRIPTION
Some tests in ndt5/c2s rely on Linux-specific TCP features (e.g., TCP_INFO) and assume Linux kernel behavior. When executed on non-Linux platforms such as Windows, these tests hang or time out instead of failing fast.

This PR adds a runtime OS guard to skip these tests when `runtime.GOOS != "linux"`.

 ## Problem

Running `go test ./...` on Windows resulted in:

- 10-minute test timeout in `Test_DrainForeverButMeasureFor_NormalOperation`
- Hanging behavior due to missing Linux TCP features
- Poor contributor experience on non-Linux systems
- The tests depend on Linux-specific socket metrics that are not available on Windows.

## Solution

Add:
```
if runtime.GOOS != "linux" {
    t.Skip("Skipping test: requires Linux TCP features")
}
```
to the affected tests in `ndt5/c2s/c2s_test.go`.

This ensures:

- Tests run fully in Linux (CI environment)
- Non-Linux contributors do not experience long hangs
- Clear indication that the test is platform-specific

Impact

- Improves cross-platform developer experience
- Prevents long timeouts during local testing
- Maintains full coverage in Linux CI
- Does not change runtime or production behavior

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/424)
<!-- Reviewable:end -->
