### PR TITLE
Validate `early_exit` parameter parsing and return error on invalid values

### DIFF
--- a/ndt7/handler/handler.go
+++ b/ndt7/handler/handler.go
@@ -277,6 +277,9 @@ func validateEarlyExit(values url.Values) (*sender.Params, error) {
 
 		// Convert string to int64.
 		bytes, _ := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s parameter value %s", name, value)
+		}
 		return &sender.Params{
 			IsEarlyExit: true,
 			MaxBytes:    bytes * 1000000, // Conver MB to bytes.


### PR DESCRIPTION
The `validateEarlyExit` function currently ignores errors returned by `strconv.ParseInt` when parsing the `early_exit` query parameter.

If a malformed value (e.g., ?early_exit=abc) is provided, parsing fails silently and bytes defaults to 0. This results in MaxBytes being set to 0 without returning an error, leading to inconsistent and unexpected behavior.

This PR adds proper error handling to ensure invalid `early_exit` values return a validation error.

## Problem

Current implementation:
```
bytes, _ := strconv.ParseInt(value, 10, 64)
```
Issues:

- Parsing errors are ignored
- Invalid numeric input silently becomes 0
- No client-visible error is returned
- No logging occurs
- Results in unintended early-exit behavior

## Solution

Check and handle parsing errors explicitly:
```
bytes, err := strconv.ParseInt(value, 10, 64)
if err != nil {
    return nil, fmt.Errorf("invalid %s parameter value %s", name, value)
}
```
This ensures:

- Invalid values return HTTP 400
- Behavior is predictable
- No silent misconfiguration
- Clear feedback to clients

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/425)
<!-- Reviewable:end -->
