### PR TITLE
fix(ndt7-protocol.md): clarify test "runtime" concept

### DIFF
--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -7,7 +7,7 @@ protocol](https://github.com/ndt-project/ndt). Ndt7 is based on
 WebSocket and TLS, and takes advantage of TCP BBR, where this
 flavour of TCP is available.
 
-This is version v0.10.0 of the ndt7 specification.
+This is version v0.11.0 of the ndt7 specification.
 
 ## Design choices
 
@@ -55,8 +55,9 @@ clients should be maximally simple, and that all complexity should
 implemented on the server side.
 
 Ndt7 should consume few resources. The maximum runtime of a test should
-be ten seconds, but the server should be able to determine if the performance
-if performance has stabilized in less than ten seconds and end the test early.
+be ten seconds counted starting from when the WebSocket handshake
+completed. The server should be able to determine if the performance
+has stabilized in less than ten seconds and end the test early.
 
 ## Protocol description
 
@@ -122,6 +123,11 @@ Connection: Upgrade\r\n
 \r\n
 ```
 
+The client SHOULD set a reasonable timeout (e.g., 5-10 seconds) to
+allow for the TCP connect, TLS handshake, and WebSocket handshake
+to complete. The test proper starts _after_ the WebSocket handshake
+has successfully completed.
+
 ### WebSocket channel usage
 
 Once the WebSocket channel is established, the client and the server
@@ -157,8 +163,9 @@ MAY change the size of such messages to accommodate for fast clients, as
 mentioned above. See the appendix for a possible algorithm to dynamically
 change the message size.
 
-The expected duration of a test is _up to_ ten seconds. If a test has
-been running for at least thirteen seconds, an implementation MAY close the
+The expected duration of a test is _up to_ ten seconds. The zero time to
+establish duration is the time when the WebSocket handshake completed. If
+a test has been running for at least 13 seconds, an implementation MAY close the
 underlying TLS connection. This is allowed to keep the overall duration
 of each test within a thirteen second upper bound. Ideally this SHOULD
 be implemented so that immediately after thirteen seconds have elapsed, the

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -55,9 +55,9 @@ clients should be maximally simple, and that all complexity should
 implemented on the server side.
 
 Ndt7 should consume few resources. The maximum runtime of a test should
-be ten seconds counted starting from when the WebSocket handshake
-completed. The server should be able to determine if the performance
-has stabilized in less than ten seconds and end the test early.
+be ten seconds since the WebSocket handshake completed. The server should
+be able to determine if the performance has stabilized in less than
+ten seconds and end the test early.
 
 ## Protocol description
 

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -57,7 +57,7 @@ implemented on the server side.
 Ndt7 should consume few resources. The maximum runtime of a test should
 be ten seconds since the WebSocket handshake completed. The server should
 be able to determine if the performance has stabilized in less than
-ten seconds and end the test early.
+ten seconds and, if so, end the test early.
 
 ## Protocol description
 

--- a/spec/ndt7-protocol.md
+++ b/spec/ndt7-protocol.md
@@ -165,8 +165,8 @@ change the message size.
 
 The expected duration of a test is _up to_ ten seconds. The zero time to
 establish duration is the time when the WebSocket handshake completed. If
-a test has been running for at least 13 seconds, an implementation MAY close the
-underlying TLS connection. This is allowed to keep the overall duration
+a test has been running for at least thirdteen seconds, an implementation MAY
+close the underlying TLS connection. This is allowed to keep the overall duration
 of each test within a thirteen second upper bound. Ideally this SHOULD
 be implemented so that immediately after thirteen seconds have elapsed, the
 underlying TLS connection is closed. This can be implemented, e.g., in C/C++


### PR DESCRIPTION
Existing historical clients (e.g., the minimal JavaScript client and the minimal Go client) did not have a consistent definition of the runtime, with the JavaScript client erring on the side of including the TCP+TLS+WebSocket handshake time and the Go client, instead, erring on the side of not including it.

This diff clarifies the matter. After a conversation with @robertodauria, and taking into account https://github.com/m-lab/ndt7-js/pull/111 and https://github.com/m-lab/msak-js/pull/23, we determined that it is probably better to adopt the behavior originally implemented by the minimal Go client.

The rationale for doing this is fairness. The original reason for killing a test unconditionally after ten seconds in JavaScript was grounded in UX concerns (do not keep the user waiting for more than 20 seconds overall). However, with high RTTs, this also means providing a less useful overall goodput estimate. To remediate this, we allow the client to run for more time.

Refer to the aforementioned pull requests for a more-in-depth analysis of this behavior, which helps reconstructing the chain of thoughts that led us to implement this spec change.

Since this diff is a spec clarification that correctly defines the concept of runtime, I am opting to bump the minor version of the spec.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/426)
<!-- Reviewable:end -->
