### PR TITLE
fix(ndt7): enumerate TCPInfo/BBRInfo fields to match legacy BigQuery order

### DIFF
--- a/ndt7/measurer/measurer.go
+++ b/ndt7/measurer/measurer.go
@@ -64,14 +64,8 @@ func measure(measurement *model.Measurement, ci netx.ConnInfo, elapsed time.Dura
 	t := int64(elapsed / time.Microsecond)
 	bbrinfo, tcpInfo, err := ci.ReadInfo()
 	if err == nil {
-		measurement.BBRInfo = &model.BBRInfo{
-			BBRInfo:     bbrinfo,
-			ElapsedTime: t,
-		}
-		measurement.TCPInfo = &model.TCPInfo{
-			LinuxTCPInfo: tcpInfo,
-			ElapsedTime:  t,
-		}
+		measurement.BBRInfo = model.NewBBRInfo(bbrinfo, t)
+		measurement.TCPInfo = model.NewTCPInfo(tcpInfo, t)
 	}
 }
 

--- a/ndt7/model/archivaldata.go
+++ b/ndt7/model/archivaldata.go
@@ -25,11 +25,17 @@ type ArchivalData struct {
 // The Measurement struct contains measurement results. This structure is
 // meant to be serialised as JSON as sent as a textual message. This
 // structure is specified in the ndt7 specification.
+//
+// NOTE: the declaration order of these fields determines the BigQuery column
+// order produced by bigquery.InferSchema (see cmd/generate-schemas) and must
+// match the legacy ndt7 table so the autoloaded and parser tables can be
+// UNION'd without corruption (see m-lab/etl-schema ndt7_union, issue #195).
+// New fields MUST be appended at the END.
 type Measurement struct {
 	AppInfo        *AppInfo        `json:",omitempty"`
-	ConnectionInfo *ConnectionInfo `json:",omitempty"`
 	BBRInfo        *BBRInfo        `json:",omitempty"`
 	TCPInfo        *TCPInfo        `json:",omitempty"`
+	ConnectionInfo *ConnectionInfo `json:",omitempty"`
 }
 
 // AppInfo contains an application level measurement. This structure is
@@ -51,14 +57,179 @@ type ConnectionInfo struct {
 // The BBRInfo struct contains information measured using BBR. This structure is
 // an extension to the ndt7 specification. Variables here have the same
 // measurement unit that is used by the Linux kernel.
+//
+// NOTE: the fields of inetdiag.BBRInfo are enumerated explicitly (rather than
+// embedded) so that the BigQuery column order is controlled here and matches
+// the legacy ndt7 table. New fields MUST be appended at the END. Populate with
+// NewBBRInfo.
 type BBRInfo struct {
-	inetdiag.BBRInfo
+	BW         int64  `csv:"BBR.BW"`         // Max-filtered BW (app throughput) estimate in bytes/second
+	MinRTT     uint32 `csv:"BBR.MinRTT"`     // Min-filtered RTT in uSec
+	PacingGain uint32 `csv:"BBR.PacingGain"` // Pacing gain shifted left 8 bits
+	CwndGain   uint32 `csv:"BBR.CwndGain"`   // Cwnd gain shifted left 8 bits
+
 	ElapsedTime int64
+}
+
+// NewBBRInfo builds a BBRInfo from an inetdiag.BBRInfo sampled from the kernel.
+func NewBBRInfo(bbr inetdiag.BBRInfo, elapsed int64) *BBRInfo {
+	return &BBRInfo{
+		BW:          bbr.BW,
+		MinRTT:      bbr.MinRTT,
+		PacingGain:  bbr.PacingGain,
+		CwndGain:    bbr.CwndGain,
+		ElapsedTime: elapsed,
+	}
 }
 
 // The TCPInfo struct contains information measured using TCP_INFO. This
 // structure is described in the ndt7 specification.
+//
+// NOTE: the fields of tcp.LinuxTCPInfo are enumerated explicitly (rather than
+// embedded) so that the BigQuery column order is controlled here. The order
+// below reproduces the legacy ndt7 BigQuery table exactly: ElapsedTime sits
+// between ReordSeen and RcvOooPack/SndWnd for historical reasons (those two
+// kernel fields were added to the legacy table after ElapsedTime already
+// existed). Matching this order lets the autoloaded tables be UNION'd with the
+// legacy parser table without corrupting nested values (issue #195).
+//
+// IMPORTANT: any NEW field (added to tcp.LinuxTCPInfo upstream, or added here)
+// MUST be appended at the END, after SndWnd. Never insert in the middle.
+// Populate with NewTCPInfo.
 type TCPInfo struct {
-	tcp.LinuxTCPInfo
+	State       uint8 `csv:"TCP.State"`
+	CAState     uint8 `csv:"TCP.CAState"`
+	Retransmits uint8 `csv:"TCP.Retransmits"`
+	Probes      uint8 `csv:"TCP.Probes"`
+	Backoff     uint8 `csv:"TCP.Backoff"`
+	Options     uint8 `csv:"TCP.Options"`
+	WScale      uint8 `csv:"TCP.WScale"`
+	AppLimited  uint8 `csv:"TCP.AppLimited"`
+
+	RTO    uint32 `csv:"TCP.RTO"`
+	ATO    uint32 `csv:"TCP.ATO"`
+	SndMSS uint32 `csv:"TCP.SndMSS"`
+	RcvMSS uint32 `csv:"TCP.RcvMSS"`
+
+	Unacked uint32 `csv:"TCP.Unacked"`
+	Sacked  uint32 `csv:"TCP.Sacked"`
+	Lost    uint32 `csv:"TCP.Lost"`
+	Retrans uint32 `csv:"TCP.Retrans"`
+	Fackets uint32 `csv:"TCP.Fackets"`
+
+	LastDataSent uint32 `csv:"TCP.LastDataSent"`
+	LastAckSent  uint32 `csv:"TCP.LastAckSent"`
+	LastDataRecv uint32 `csv:"TCP.LastDataRecv"`
+	LastAckRecv  uint32 `csv:"TCP.LastDataRecv"`
+
+	PMTU        uint32 `csv:"TCP.PMTU"`
+	RcvSsThresh uint32 `csv:"TCP.RcvSsThresh"`
+	RTT         uint32 `csv:"TCP.RTT"`
+	RTTVar      uint32 `csv:"TCP.RTTVar"`
+	SndSsThresh uint32 `csv:"TCP.SndSsThresh"`
+	SndCwnd     uint32 `csv:"TCP.SndCwnd"`
+	AdvMSS      uint32 `csv:"TCP.AdvMSS"`
+	Reordering  uint32 `csv:"TCP.Reordering"`
+
+	RcvRTT   uint32 `csv:"TCP.RcvRTT"`
+	RcvSpace uint32 `csv:"TCP.RcvSpace"`
+
+	TotalRetrans uint32 `csv:"TCP.TotalRetrans"`
+
+	PacingRate    int64 `csv:"TCP.PacingRate"`
+	MaxPacingRate int64 `csv:"TCP.MaxPacingRate"`
+
+	BytesAcked    int64 `csv:"TCP.BytesAcked"`
+	BytesReceived int64 `csv:"TCP.BytesReceived"`
+	SegsOut       int32 `csv:"TCP.SegsOut"`
+	SegsIn        int32 `csv:"TCP.SegsIn"`
+
+	NotsentBytes uint32 `csv:"TCP.NotsentBytes"`
+	MinRTT       uint32 `csv:"TCP.MinRTT"`
+	DataSegsIn   uint32 `csv:"TCP.DataSegsIn"`
+	DataSegsOut  uint32 `csv:"TCP.DataSegsOut"`
+
+	DeliveryRate int64 `csv:"TCP.DeliveryRate"`
+
+	BusyTime      int64 `csv:"TCP.BusyTime"`
+	RWndLimited   int64 `csv:"TCP.RWndLimited"`
+	SndBufLimited int64 `csv:"TCP.SndBufLimited"`
+
+	Delivered   uint32 `csv:"TCP.Delivered"`
+	DeliveredCE uint32 `csv:"TCP.DeliveredCE"`
+
+	BytesSent    int64 `csv:"TCP.BytesSent"`
+	BytesRetrans int64 `csv:"TCP.BytesRetrans"`
+
+	DSackDups uint32 `csv:"TCP.DSackDups"`
+	ReordSeen uint32 `csv:"TCP.ReordSeen"`
+
+	// ElapsedTime is intentionally placed here (not last) to match the legacy
+	// ndt7 BigQuery table; RcvOooPack and SndWnd follow it. Append new fields
+	// AFTER SndWnd only.
 	ElapsedTime int64
+
+	RcvOooPack uint32 `csv:"TCP.RcvOooPack"`
+	SndWnd     uint32 `csv:"TCP.SndWnd"`
+}
+
+// NewTCPInfo builds a TCPInfo from a tcp.LinuxTCPInfo sampled from the kernel.
+func NewTCPInfo(ti tcp.LinuxTCPInfo, elapsed int64) *TCPInfo {
+	return &TCPInfo{
+		State:         ti.State,
+		CAState:       ti.CAState,
+		Retransmits:   ti.Retransmits,
+		Probes:        ti.Probes,
+		Backoff:       ti.Backoff,
+		Options:       ti.Options,
+		WScale:        ti.WScale,
+		AppLimited:    ti.AppLimited,
+		RTO:           ti.RTO,
+		ATO:           ti.ATO,
+		SndMSS:        ti.SndMSS,
+		RcvMSS:        ti.RcvMSS,
+		Unacked:       ti.Unacked,
+		Sacked:        ti.Sacked,
+		Lost:          ti.Lost,
+		Retrans:       ti.Retrans,
+		Fackets:       ti.Fackets,
+		LastDataSent:  ti.LastDataSent,
+		LastAckSent:   ti.LastAckSent,
+		LastDataRecv:  ti.LastDataRecv,
+		LastAckRecv:   ti.LastAckRecv,
+		PMTU:          ti.PMTU,
+		RcvSsThresh:   ti.RcvSsThresh,
+		RTT:           ti.RTT,
+		RTTVar:        ti.RTTVar,
+		SndSsThresh:   ti.SndSsThresh,
+		SndCwnd:       ti.SndCwnd,
+		AdvMSS:        ti.AdvMSS,
+		Reordering:    ti.Reordering,
+		RcvRTT:        ti.RcvRTT,
+		RcvSpace:      ti.RcvSpace,
+		TotalRetrans:  ti.TotalRetrans,
+		PacingRate:    ti.PacingRate,
+		MaxPacingRate: ti.MaxPacingRate,
+		BytesAcked:    ti.BytesAcked,
+		BytesReceived: ti.BytesReceived,
+		SegsOut:       ti.SegsOut,
+		SegsIn:        ti.SegsIn,
+		NotsentBytes:  ti.NotsentBytes,
+		MinRTT:        ti.MinRTT,
+		DataSegsIn:    ti.DataSegsIn,
+		DataSegsOut:   ti.DataSegsOut,
+		DeliveryRate:  ti.DeliveryRate,
+		BusyTime:      ti.BusyTime,
+		RWndLimited:   ti.RWndLimited,
+		SndBufLimited: ti.SndBufLimited,
+		Delivered:     ti.Delivered,
+		DeliveredCE:   ti.DeliveredCE,
+		BytesSent:     ti.BytesSent,
+		BytesRetrans:  ti.BytesRetrans,
+		DSackDups:     ti.DSackDups,
+		ReordSeen:     ti.ReordSeen,
+		ElapsedTime:   elapsed,
+		RcvOooPack:    ti.RcvOooPack,
+		SndWnd:        ti.SndWnd,
+	}
 }


### PR DESCRIPTION
## Summary

De-embed `tcp.LinuxTCPInfo`/`inetdiag.BBRInfo` in the ndt7 model and enumerate their fields explicitly, ordered to reproduce the **legacy ndt7 BigQuery table**; reorder `Measurement` to `[AppInfo, BBRInfo, TCPInfo, ConnectionInfo]`. Adds `NewTCPInfo`/`NewBBRInfo` constructors; the measurer uses them.

`bigquery.InferSchema` previously emitted `TCPInfo.ElapsedTime` last (an artifact of embedding + a trailing field), so newly-autoloaded ndt7 tables diverged from the legacy parser table's nested field order. `UNION ALL [BY NAME]` coerces nested structs **positionally**, silently corrupting `TCPInfo` values (m-lab/etl-schema#195). Explicit enumeration makes the generated schema match the legacy table and enforces **append-new-fields-at-the-end** going forward.

## Verification
- Regenerated ndt7 schema: full `TCPInfo` order is identical to `measurement-lab.ndt.ndt7` (55/55 fields), and `Measurement` matches `[AppInfo, BBRInfo, TCPInfo, ConnectionInfo]`.
- JSON wire format unchanged (identical field names) → no impact on emitted data or existing parsers.
- `go build ./...` and `go vet ./ndt7/...` pass.

Part of the fix for m-lab/etl-schema#195. Follow-ups (separate PRs): deploy the schema to GCS, then recreate the existing autojoin `ndt7_raw` tables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/433)
<!-- Reviewable:end -->
