### PR TITLE
fix(generate-schemas): generate ndt5 schema from NDT5Result

### DIFF
--- a/cmd/generate-schemas/main.go
+++ b/cmd/generate-schemas/main.go
@@ -33,7 +33,7 @@ func main() {
 	ioutil.WriteFile(ndt7schema, b, 0o644)
 
 	// Generate and save ndt5 schema for autoloading.
-	row5 := data.NDT7Result{}
+	row5 := data.NDT5Result{}
 	sch, err = bigquery.InferSchema(row5)
 	rtx.Must(err, "failed to generate ndt5 schema")
 	sch = bqx.RemoveRequired(sch)


### PR DESCRIPTION
generate-schemas built the ndt5 schema from `data.NDT7Result`, so `ndt5.json` contained the NDT7 schema (`Upload`/`Download`) instead of the NDT5 one (`Control`/`C2S`/`S2C`). Copy-paste bug dating back to #384.

- Generate the ndt5 schema from `data.NDT5Result`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server/437)
<!-- Reviewable:end -->
